### PR TITLE
Fix script errors and return type

### DIFF
--- a/transactions/scripts/read_listing_details.cdc
+++ b/transactions/scripts/read_listing_details.cdc
@@ -2,8 +2,8 @@ import NFTStorefront from "../../contracts/NFTStorefront.cdc"
 
 // This script returns the details for a listing within a storefront
 
-pub fun main(account: Address, listingResourceID: UInt64): [UInt64] {
-    let storefrontRef = account
+pub fun main(account: Address, listingResourceID: UInt64): NFTStorefront.ListingDetails {
+    let storefrontRef = getAccount(account)
         .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(
             NFTStorefront.StorefrontPublicPath
         )

--- a/transactions/scripts/read_storefront_ids.cdc
+++ b/transactions/scripts/read_storefront_ids.cdc
@@ -3,7 +3,7 @@ import NFTStorefront from "../../contracts/NFTStorefront.cdc"
 // This script returns an array of all the nft uuids for sale through a Storefront
 
 pub fun main(account: Address): [UInt64] {
-    let storefrontRef = account
+    let storefrontRef = getAccount(account)
         .getCapability<&NFTStorefront.Storefront{NFTStorefront.StorefrontPublic}>(
             NFTStorefront.StorefrontPublicPath
         )


### PR DESCRIPTION
Scripts were missing the `getAccount()` function and read_listing_details had the wrong return type

See #17 