### PR TITLE
Update readme and deploy the storefrontV2 on testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,14 @@ facilities to implement a marketplace that can take any currency in order to ven
 This means that only one instance of the contract is needed (see below for its address on Testnet and Mainnet), 
 and its resources, transactions, and scripts can be used by any account to create any marketplace.
 
+> **_NOTE:_** New version of NFTStorefront,i.e. `NFTStorefrontV2` contract has been developed and deployed on testnet. Whoever wants to build upon NFTStorefront, it is recommended to use latest version of it,i.e `NFTStorefrontV2` and enjoy its latest offerings.
+
 ## Contract Addresses 
 
 |Name|Testnet|Mainnet|
 |----|-------|-------|
 |[NFTStorefront](contracts/NFTStorefront.cdc)|[0x94b06cfca1d8a476](https://flow-view-source.com/testnet/account/0x94b06cfca1d8a476/contract/NFTStorefront)|[0x4eb8a10cb9f87357](https://flowscan.org/contract/A.4eb8a10cb9f87357.NFTStorefront)|
+|[NFTStorefrontV2](contracts/NFTStorefrontV2.cdc)|[0x2d55b98eb200daef](https://flow-view-source.com/testnet/account/0x2d55b98eb200daef/contract/NFTStorefrontV2)||
 
 ## Usage
 

--- a/flow.json
+++ b/flow.json
@@ -7,6 +7,7 @@
   },
   "contracts": {
     "NFTStorefront": "./contracts/NFTStorefront.cdc",
+    "NFTStorefrontV2": "./contracts/NFTStorefrontV2.cdc",
     "FungibleToken": {
       "source": "./contracts/FungibleToken.cdc",
       "aliases": {
@@ -36,7 +37,7 @@
   "deployments": {
     "emulator": {
       "emulator-account": [
-        "NFTStorefront"
+        "NFTStorefrontV2"
       ]
     }
   }

--- a/flow.testnet.json
+++ b/flow.testnet.json
@@ -1,14 +1,20 @@
 {
   "accounts": {
-    "nft-storefront-testnet": {
-      "address": "0x94b06cfca1d8a476",
-      "key": "${NFT_STOREFRONT_TESTNET_PRIVATE_KEY}"
+    "nft-storefront-v2-testnet": {
+      "address": "0x2d55b98eb200daef",
+      "key": "${PRIVATE_KEY}"
     }
+  },
+  "contracts": {
+      "NFTStorefrontV2": "./contracts/NFTStorefrontV2.cdc"
+  },
+  "networks": {
+      "testnet": "access.devnet.nodes.onflow.org:9000"
   },
   "deployments": {
     "testnet": {
-      "nft-storefront-testnet": [
-        "NFTStorefront"
+      "nft-storefront-v2-testnet": [
+        "NFTStorefrontV2"
       ]
     }
   }


### PR DESCRIPTION
- PR updates the readme and highlights the NFTStorefrontV2 to use instead of the older version.
- Add the testnet address of the NFTStorefrontV2.