### PR TITLE
Remove MetadataViews reference from the V2 contract

### DIFF
--- a/contracts/NFTStorefrontV2.cdc
+++ b/contracts/NFTStorefrontV2.cdc
@@ -1,6 +1,5 @@
 import FungibleToken from "./utility/FungibleToken.cdc"
 import NonFungibleToken from "./utility/NonFungibleToken.cdc"
-import MetadataViews from "./utility/MetadataViews.cdc"
 
 /// NFTStorefrontV2
 ///


### PR DESCRIPTION
Changelog -

- Remove the MetadataViews reference from the V2 contract.


Closes #51 