### PR TITLE
Make Commission details accessible in V2 contract

### DIFF
--- a/contracts/NFTStorefrontV2.cdc
+++ b/contracts/NFTStorefrontV2.cdc
@@ -1,6 +1,5 @@
 import FungibleToken from "./utility/FungibleToken.cdc"
 import NonFungibleToken from "./utility/NonFungibleToken.cdc"
-import MetadataViews from "./utility/MetadataViews.cdc"
 
 /// NFTStorefrontV2
 ///

--- a/flow.json
+++ b/flow.json
@@ -8,14 +8,14 @@
   "contracts": {
     "NFTStorefront": "./contracts/NFTStorefront.cdc",
     "FungibleToken": {
-      "source": "./contracts/FungibleToken.cdc",
+      "source": "./contracts/utility/FungibleToken.cdc",
       "aliases": {
         "emulator": "0xee82856bf20e2aa6",
         "testnet": "0x9a0766d93b6608b7"
       }
     },
     "NonFungibleToken": {
-      "source": "./contracts/NonFungibleToken.cdc",
+      "source": "./contracts/utility/NonFungibleToken.cdc",
       "aliases": {
         "emulator": "0xf8d6e0586b0a20c7",
         "testnet": "0x631e88ae7f1d7c20"
@@ -36,8 +36,9 @@
   "deployments": {
     "emulator": {
       "emulator-account": [
-        "NFTStorefront"
+        "FungibleToken", "NonFungibleToken", "NFTStorefront"
       ]
     }
   }
 }
+ 

--- a/lib/js/test/tests/nft-storefront-v2.test.js
+++ b/lib/js/test/tests/nft-storefront-v2.test.js
@@ -48,6 +48,12 @@ async function getListingDetails(account, resourceId) {
   return scriptResult
 }
 
+async function getAllowedCommissionReceivers(account, resourceId) {
+  const read_allowed_commission_receivers = fs.readFileSync(path.resolve(__dirname, "../../../../scripts/read_allowed_commission_receivers.cdc"), {encoding:'utf8', flag:'r'});
+  const [scriptResult, sError] = await executeScript({ code: read_allowed_commission_receivers, args: [account, resourceId] });
+  return scriptResult
+}
+
 async function getRoyaltyBalance(account) {
   const code =
   `import FlowToken from 0x0ae53cb6e3f42a79
@@ -214,7 +220,8 @@ describe("NFTStorefrontV2", ()=> {
     const [txResult_2, error_2] = await shallPass(
       sendTransaction({
         name: "sell_item",
-        args: [0, "50.50", "TopShot Platform", "10.50", currentTimestamp + 500,[]],
+        // Use 0 for the commission amount to make sure it supports the creation of the sale at 0 commission.
+        args: [0, "50.50", "TopShot Platform", "0", currentTimestamp + 500,[]],
         signers: [seller_1]
       })
     ); 
@@ -329,6 +336,11 @@ describe("NFTStorefrontV2", ()=> {
     expect(parseInt(listingDetails.expiry)).toEqual(currentTimestamp + 500);
     expect(listingDetails.customID).toEqual("TopShot Platform");
     expect(listingDetails.salePrice).toEqual('50.50000000');
+    // Make sure that anybody can retrieve the list of the marketplaces capability supported by the listing.
+    const allowedCommissionRecv = await getAllowedCommissionReceivers(seller_1, listingKeys[0]);
+    console.log(allowedCommissionRecv);
+    expect(allowedCommissionRecv[0].address).toEqual(marketplace_1);
+    expect(allowedCommissionRecv[1].address).toEqual(marketplace_2);
   });
 
   test("should successfully list the same item multiple times and then purchase one of the listing that removes other duplicates programmatically", async() => {

--- a/scripts/read_allowed_commission_receivers.cdc
+++ b/scripts/read_allowed_commission_receivers.cdc
@@ -1,0 +1,17 @@
+import NFTStorefrontV2 from "../contracts/NFTStorefrontV2.cdc"
+import FungibleToken   from "../contracts/utility/FungibleToken.cdc"
+
+// This script returns the list of allowed commission receivers supported by the given listing Id.
+pub fun main(account: Address, listingResourceID: UInt64): [Capability<&{FungibleToken.Receiver}>]? {
+    let storefrontRef = getAccount(account)
+        .getCapability<&NFTStorefrontV2.Storefront{NFTStorefrontV2.StorefrontPublic}>(
+            NFTStorefrontV2.StorefrontPublicPath
+        )
+        .borrow()
+        ?? panic("Could not borrow public storefront from address")
+
+    let listing = storefrontRef.borrowListing(listingResourceID: listingResourceID)
+        ?? panic("No item with that ID")
+    
+    return listing.getAllowedCommissionReceivers()
+}


### PR DESCRIPTION
Changelog - 

- Add a public function that will allow anyone to know the allowed commission receivers for a listing.
- Emit all the allowed commission receiver's addresses in the `ListingAvailable` event.
- Emit the commission beneficiary address in the `ListingCompleted` event.

Resolves #50 