### PR TITLE
Allow zero commission recipient during purchase

### DIFF
--- a/lib/js/test/tests/nft-storefront-v2.test.js
+++ b/lib/js/test/tests/nft-storefront-v2.test.js
@@ -535,6 +535,132 @@ describe("NFTStorefrontV2", ()=> {
   });
 
 
+  test("should successfully list the item with the zero commission receipt and buy with it", async() => {
+    // step 1 : Setup a collection for seller_1
+    await shallPass(
+      sendTransaction({
+        code: setup_nft_account_tx,
+        args: [],
+        signers: [seller_1]
+      })
+    );
+
+    // step 2: Mint NFT for seller_1 with royalties 
+    // step 2.a: Provide the receiver capability.
+    
+    // For artist_1
+    await shallPass(
+      sendTransaction({
+        code: setup_account_to_receive_royalty_tx,
+        args:[],
+        signers: [artist_1]
+      })
+    );
+
+    // For artist_2
+    await shallPass(
+      sendTransaction({
+        code: setup_account_to_receive_royalty_tx,
+        args:[],
+        signers: [artist_2]
+      })
+    );
+    
+    // Mint the NFT
+    await shallPass(
+      sendTransaction({
+        code: mint_nft_tx,
+        args: [seller_1, "NFT1", "This is to sell", "abc.jpeg", ["0.1", "0.25"], ["Artist_1", "Artist_2"], [artist_1, artist_2]],
+        signers: [exampleNFTContractAddress]
+      })
+    );
+
+    // Verify the Id of the NFT that get minted
+    const [result, e] = await executeScript({
+      code: get_owned_nft_ids_script,
+      args: [seller_1]
+    });
+    expect(result.length).toBe(1);
+    expect(result[0]).toEqual(0);
+
+    // Check the capability for the flow token
+    expect(await doesFlowTokenReceiverCapabilityExists(seller_1)).toBeTruthy();
+
+    // Step 4: List NFT to sell, It would list the nft for the sale with commission can be grab by anyone.
+    const currentTimestamp = parseInt(await getCurrentTimestamp());
+
+    // Step 4.a: Install the storefront manager in the seller_1 account.
+    await shallPass(
+      sendTransaction({
+        name: "setup_account",
+        args: [],
+        signers: [seller_1]
+      })
+    );
+
+    // Step 4.b: Should success as seller_1 has the storefront manager resource with marketplace address
+    let [txResult_2, error_2] = await shallPass(
+      sendTransaction({
+        name: "sell_item",
+        args: [0, "50.50", "TopShot Platform", "0.0", currentTimestamp + 500, [marketplace_1, marketplace_2]],
+        signers: [seller_1]
+      })
+    ); 
+    
+    // Make sure transaction did go through.
+    expect(error_2).toEqual(null);
+
+    // Validate the details
+    let listingKeys = await getListingKeys(seller_1);
+    expect(listingKeys.length).toEqual(1);
+
+    let listingDetails = await getListingDetails(seller_1, listingKeys[0]);
+    expect(listingDetails.purchased).toBeFalsy();
+    expect(parseInt(listingDetails.expiry)).toEqual(currentTimestamp + 500);
+    expect(listingDetails.customID).toEqual("TopShot Platform");
+    expect(listingDetails.salePrice).toEqual('50.50000000');
+
+    
+    //////////////
+    // Purchase///
+    //////////////
+
+    // Mint effective salePrice amount to buyer_1
+    await mintFlow(buyer_1, "1000.0");
+    const [flowBalance, ] = await getFlowBalance(buyer_1);
+    console.log(`Flow balance for buyer 1 - ${flowBalance}`);
+
+    // Install NFT receiver in the buyer account
+    await shallPass(
+      sendTransaction({
+        code: setup_nft_account_tx,
+        args: [],
+        signers: [buyer_1]
+      })
+    );
+
+    // Should fail as commission can only be send to marketplaces.
+    const [txResult_purchase, error_purchase] = await shallPass(
+      sendTransaction({
+        name: "buy_item",
+        args: [listingKeys[0], seller_1, null],
+        signers: [buyer_1]
+      })
+    );
+
+    // Make sure the transaction fails
+    expect(error_purchase).toEqual(null);
+
+    // Verify the buyer got the NFT.
+    const [nft_ids, ] = await executeScript({
+      code: get_owned_nft_ids_script,
+      args: [buyer_1]
+    });
+    expect(nft_ids.length).toBe(1);
+    expect(result[0]).toEqual(0);
+  });
+
+
   test("Cleanup expired listings", async() => {
     // step 1 : Setup a collection for seller_1
     await shallPass(


### PR DESCRIPTION
Changelog - 

- Add support of providing the optional `commissionRecipient` during the purchase so if the `commissionAmount` is zero, dApp doesn't need to provide any arbitrary capability to work.