### PR TITLE
Implement Storefront Transactions Using The NFT Catalog.

### DIFF
--- a/contracts/utility/MetadataViews.cdc
+++ b/contracts/utility/MetadataViews.cdc
@@ -1,36 +1,91 @@
-/**
-
-This contract implements the metadata standard proposed
-in FLIP-0636.
-
-Ref: https://github.com/onflow/flow/blob/master/flips/20210916-nft-metadata.md
-
-Structs and resources can implement one or more
-metadata types, called views. Each view type represents
-a different kind of metadata, such as a creator biography
-or a JPEG image file.
-*/
-
 import FungibleToken from "./FungibleToken.cdc"
 import NonFungibleToken from "./NonFungibleToken.cdc"
 
+/// This contract implements the metadata standard proposed
+/// in FLIP-0636.
+/// 
+/// Ref: https://github.com/onflow/flow/blob/master/flips/20210916-nft-metadata.md
+/// 
+/// Structs and resources can implement one or more
+/// metadata types, called views. Each view type represents
+/// a different kind of metadata, such as a creator biography
+/// or a JPEG image file.
+///
 pub contract MetadataViews {
 
-    /// A Resolver provides access to a set of metadata views.
-    ///
-    /// A struct or resource (e.g. an NFT) can implement this interface
-    /// to provide access to the views that it supports.
+    /// Provides access to a set of metadata views. A struct or 
+    /// resource (e.g. an NFT) can implement this interface to provide access to 
+    /// the views that it supports.
     ///
     pub resource interface Resolver {
         pub fun getViews(): [Type]
         pub fun resolveView(_ view: Type): AnyStruct?
     }
 
-    /// A ResolverCollection is a group of view resolvers index by ID.
+    /// A group of view resolvers indexed by ID.
     ///
     pub resource interface ResolverCollection {
         pub fun borrowViewResolver(id: UInt64): &{Resolver}
         pub fun getIDs(): [UInt64]
+    }
+
+    /// NFTView wraps all Core views along `id` and `uuid` fields, and is used 
+    /// to give a complete picture of an NFT. Most NFTs should implement this 
+    /// view.
+    ///
+    pub struct NFTView {
+        pub let id: UInt64
+        pub let uuid: UInt64
+        pub let display: Display?
+        pub let externalURL: ExternalURL?
+        pub let collectionData: NFTCollectionData?
+        pub let collectionDisplay: NFTCollectionDisplay?
+        pub let royalties: Royalties?
+        pub let traits: Traits?
+
+        init(
+            id : UInt64,
+            uuid : UInt64,
+            display : Display?,
+            externalURL : ExternalURL?,
+            collectionData : NFTCollectionData?,
+            collectionDisplay : NFTCollectionDisplay?,
+            royalties : Royalties?,
+            traits: Traits?
+        ) {
+            self.id = id
+            self.uuid = uuid
+            self.display = display
+            self.externalURL = externalURL
+            self.collectionData = collectionData
+            self.collectionDisplay = collectionDisplay
+            self.royalties = royalties
+            self.traits = traits
+        }
+    }
+
+    /// Helper to get an NFT view 
+    ///
+    /// @param id: The NFT id
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return A NFTView struct
+    ///
+    pub fun getNFTView(id: UInt64, viewResolver: &{Resolver}) : NFTView {
+        let nftView = viewResolver.resolveView(Type<NFTView>())
+        if nftView != nil {
+            return nftView! as! NFTView
+        }
+
+        return NFTView(
+            id : id,
+            uuid: viewResolver.uuid,
+            display: self.getDisplay(viewResolver),
+            externalURL : self.getExternalURL(viewResolver),
+            collectionData : self.getNFTCollectionData(viewResolver),
+            collectionDisplay : self.getNFTCollectionDisplay(viewResolver),
+            royalties : self.getRoyalties(viewResolver),
+            traits : self.getTraits(viewResolver)
+        )
     }
 
     /// Display is a basic view that includes the name, description and
@@ -70,15 +125,28 @@ pub contract MetadataViews {
         }
     }
 
-    /// File is a generic interface that represents a file stored on or off chain.
+    /// Helper to get Display in a typesafe way
     ///
-    /// Files can be used to references images, videos and other media.
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return An optional Display struct
+    ///
+    pub fun getDisplay(_ viewResolver: &{Resolver}) : Display? {
+        if let view = viewResolver.resolveView(Type<Display>()) {
+            if let v = view as? Display {
+                return v
+            }
+        }
+        return nil
+    }
+
+    /// Generic interface that represents a file stored on or off chain. Files 
+    /// can be used to references images, videos and other media.
     ///
     pub struct interface File {
         pub fun uri(): String
     }
 
-    /// HTTPFile is a file that is accessible at an HTTP (or HTTPS) URL. 
+    /// View to expose a file that is accessible at an HTTP (or HTTPS) URL. 
     ///
     pub struct HTTPFile: File {
         pub let url: String
@@ -92,9 +160,7 @@ pub contract MetadataViews {
         }
     }
 
-    /// IPFSFile returns a thumbnail image for an object
-    /// stored as an image file in IPFS.
-    ///
+    /// View to expose a file stored on IPFS.
     /// IPFS images are referenced by their content identifier (CID)
     /// rather than a direct URI. A client application can use this CID
     /// to find and load the image via an IPFS gateway.
@@ -121,8 +187,9 @@ pub contract MetadataViews {
         }
 
         /// This function returns the IPFS native URL for this file.
-        ///
         /// Ref: https://docs.ipfs.io/how-to/address-ipfs-on-web/#native-urls
+        ///
+        /// @return The string containing the file uri
         ///
         pub fun uri(): String {
             if let path = self.path {
@@ -133,25 +200,12 @@ pub contract MetadataViews {
         }
     }
 
-    /// Editions is an optional view for collections that issues multiple objects
-    /// with the same or similar metadata, for example an X of 100 set. This information is 
-    /// useful for wallets and marketplaes.
+    /// Optional view for collections that issue multiple objects
+    /// with the same or similar metadata, for example an X of 100 set. This 
+    /// information is useful for wallets and marketplaces.
+    /// An NFT might be part of multiple editions, which is why the edition 
+    /// information is returned as an arbitrary sized array
     ///
-    /// An NFT might be part of multiple editions, which is why the edition information
-    /// is returned as an arbitrary sized array
-    /// 
-    pub struct Editions {
-
-        /// An arbitrary-sized list for any number of editions
-        /// that the NFT might be a part of
-        pub let infoList: [Edition]
-
-        init(_ infoList: [Edition]) {
-            self.infoList = infoList
-        }
-    }
-
-    /// Edition information for a single edition
     pub struct Edition {
 
         /// The name of the edition
@@ -160,13 +214,10 @@ pub contract MetadataViews {
         pub let name: String?
 
         /// The edition number of the object.
-        ///
-        /// For an "24 of 100 (#24/100)" item, the number is 24. 
-        ///
+        /// For an "24 of 100 (#24/100)" item, the number is 24.
         pub let number: UInt64
 
         /// The max edition number of this type of objects.
-        /// 
         /// This field should only be provided for limited-editioned objects.
         /// For an "24 of 100 (#24/100)" item, max is 100.
         /// For an item with unlimited edition, max should be set to nil.
@@ -183,10 +234,38 @@ pub contract MetadataViews {
         }
     }
 
-    /// A view representing a project-defined serial number for a specific NFT
+    /// Wrapper view for multiple Edition views
+    /// 
+    pub struct Editions {
+
+        /// An arbitrary-sized list for any number of editions
+        /// that the NFT might be a part of
+        pub let infoList: [Edition]
+
+        init(_ infoList: [Edition]) {
+            self.infoList = infoList
+        }
+    }
+
+    /// Helper to get Editions in a typesafe way
+    ///
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return An optional Editions struct
+    ///
+    pub fun getEditions(_ viewResolver: &{Resolver}) : Editions? {
+        if let view = viewResolver.resolveView(Type<Editions>()) {
+            if let v = view as? Editions {
+                return v
+            }
+        }
+        return nil
+    }
+
+    /// View representing a project-defined serial number for a specific NFT
     /// Projects have different definitions for what a serial number should be
-    /// Some may use the NFTs regular ID and some may use a different classification system
-    /// The serial number is expected to be unique among other NFTs within that project
+    /// Some may use the NFTs regular ID and some may use a different 
+    /// classification system. The serial number is expected to be unique among 
+    /// other NFTs within that project
     ///
     pub struct Serial {
         pub let number: UInt64
@@ -196,15 +275,63 @@ pub contract MetadataViews {
         }
     }
 
-    /*
-    *  Royalty Views
-    *  Defines the composable royalty standard that gives marketplaces a unified interface
-    *  to support NFT royalties.
-    *
-    *  Marketplaces can query this `Royalties` struct from NFTs 
-    *  and are expected to pay royalties based on these specifications.
-    *
-    */
+    /// Helper to get Serial in a typesafe way
+    ///
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return An optional Serial struct
+    ///
+    pub fun getSerial(_ viewResolver: &{Resolver}) : Serial? {
+        if let view = viewResolver.resolveView(Type<Serial>()) {
+            if let v = view as? Serial {
+                return v
+            }
+        }
+        return nil
+    }
+    
+    /// View that defines the composable royalty standard that gives marketplaces a 
+    /// unified interface to support NFT royalties.
+    ///
+    pub struct Royalty {
+
+        /// Generic FungibleToken Receiver for the beneficiary of the royalty
+        /// Can get the concrete type of the receiver with receiver.getType()
+        /// Recommendation - Users should create a new link for a FlowToken 
+        /// receiver for this using `getRoyaltyReceiverPublicPath()`, and not 
+        /// use the default FlowToken receiver. This will allow users to update 
+        /// the capability in the future to use a more generic capability
+        pub let receiver: Capability<&AnyResource{FungibleToken.Receiver}>
+
+        /// Multiplier used to calculate the amount of sale value transferred to 
+        /// royalty receiver. Note - It should be between 0.0 and 1.0 
+        /// Ex - If the sale value is x and multiplier is 0.56 then the royalty 
+        /// value would be 0.56 * x.
+        /// Generally percentage get represented in terms of basis points
+        /// in solidity based smart contracts while cadence offers `UFix64` 
+        /// that already supports the basis points use case because its 
+        /// operations are entirely deterministic integer operations and support 
+        /// up to 8 points of precision.
+        pub let cut: UFix64
+
+        /// Optional description: This can be the cause of paying the royalty,
+        /// the relationship between the `wallet` and the NFT, or anything else
+        /// that the owner might want to specify.
+        pub let description: String
+
+        init(receiver: Capability<&AnyResource{FungibleToken.Receiver}>, cut: UFix64, description: String) {
+            pre {
+                cut >= 0.0 && cut <= 1.0 : "Cut value should be in valid range i.e [0,1]"
+            }
+            self.receiver = receiver
+            self.cut = cut
+            self.description = description
+        }
+    }
+
+    /// Wrapper view for multiple Royalty views.
+    /// Marketplaces can query this `Royalties` struct from NFTs 
+    /// and are expected to pay royalties based on these specifications.
+    ///
     pub struct Royalties {
 
         /// Array that tracks the individual royalties
@@ -222,53 +349,58 @@ pub contract MetadataViews {
         }
 
         /// Return the cutInfos list
+        ///
+        /// @return An array containing all the royalties structs
+        ///
         pub fun getRoyalties(): [Royalty] {
             return self.cutInfos
         }
     }
 
-    /// Struct to store details of a single royalty cut for a given NFT
-    pub struct Royalty {
-
-        /// Generic FungibleToken Receiver for the beneficiary of the royalty
-        /// Can get the concrete type of the receiver with receiver.getType()
-        /// Recommendation - Users should create a new link for a FlowToken receiver for this using `getRoyaltyReceiverPublicPath()`,
-        /// and not use the default FlowToken receiver.
-        /// This will allow users to update the capability in the future to use a more generic capability
-        pub let receiver: Capability<&AnyResource{FungibleToken.Receiver}>
-
-        /// Multiplier used to calculate the amount of sale value transferred to royalty receiver.
-        /// Note - It should be between 0.0 and 1.0 
-        /// Ex - If the sale value is x and multiplier is 0.56 then the royalty value would be 0.56 * x.
-        ///
-        /// Generally percentage get represented in terms of basis points
-        /// in solidity based smart contracts while cadence offers `UFix64` that already supports
-        /// the basis points use case because its operations
-        /// are entirely deterministic integer operations and support up to 8 points of precision.
-        pub let cut: UFix64
-
-        /// Optional description: This can be the cause of paying the royalty,
-        /// the relationship between the `wallet` and the NFT, or anything else that the owner might want to specify
-        pub let description: String
-
-        init(recepient: Capability<&AnyResource{FungibleToken.Receiver}>, cut: UFix64, description: String) {
-            pre {
-                cut >= 0.0 && cut <= 1.0 : "Cut value should be in valid range i.e [0,1]"
+    /// Helper to get Royalties in a typesafe way
+    ///
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return A optional Royalties struct
+    ///
+    pub fun getRoyalties(_ viewResolver: &{Resolver}) : Royalties? {
+        if let view = viewResolver.resolveView(Type<Royalties>()) {
+            if let v = view as? Royalties {
+                return v
             }
-            self.receiver = recepient
-            self.cut = cut
-            self.description = description
         }
+        return nil
     }
 
     /// Get the path that should be used for receiving royalties
     /// This is a path that will eventually be used for a generic switchboard receiver,
     /// hence the name but will only be used for royalties for now.
+    ///
+    /// @return The PublicPath for the generic FT receiver
+    ///
     pub fun getRoyaltyReceiverPublicPath(): PublicPath {
         return /public/GenericFTReceiver
     }
 
-    /// Medias is an optional view for collections that issue objects with multiple Media sources in it
+    /// View to represent, a file with an correspoiding mediaType.
+    ///
+    pub struct Media {
+
+        /// File for the media
+        ///
+        pub let file: AnyStruct{File}
+
+        /// media-type comes on the form of type/subtype as described here 
+        /// https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
+        ///
+        pub let mediaType: String
+
+        init(file: AnyStruct{File}, mediaType: String) {
+          self.file=file
+          self.mediaType=mediaType
+        }
+    }
+
+    /// Wrapper view for multiple media views
     ///
     pub struct Medias {
 
@@ -280,24 +412,23 @@ pub contract MetadataViews {
         }
     }
 
-    /// A view to represent Media, a file with an correspoiding mediaType.
-    pub struct Media {
-        
-        /// File for the media
-        pub let file: AnyStruct{File}
-
-        /// media-type comes on the form of type/subtype as described here https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
-        pub let mediaType: String
-
-        init(file: AnyStruct{File}, mediaType: String) {
-          self.file=file
-          self.mediaType=mediaType
+    /// Helper to get Medias in a typesafe way
+    ///
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return A optional Medias struct
+    ///
+    pub fun getMedias(_ viewResolver: &{Resolver}) : Medias? {
+        if let view = viewResolver.resolveView(Type<Medias>()) {
+            if let v = view as? Medias {
+                return v
+            }
         }
+        return nil
     }
 
-    /// A license according to https://spdx.org/licenses/
+    /// View to represent a license according to https://spdx.org/licenses/
+    /// This view can be used if the content of an NFT is licensed.
     ///
-    /// This view can be used if the content of an NFT is licensed. 
     pub struct License {
         pub let spdxIdentifier: String
 
@@ -306,9 +437,24 @@ pub contract MetadataViews {
         }
     }
 
-    /// A view to expose a URL to this item on an external site.
+    /// Helper to get License in a typesafe way
     ///
-    /// This can be used by applications like .find and Blocto to direct users to the original link for an NFT.
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return A optional License struct
+    ///
+    pub fun getLicense(_ viewResolver: &{Resolver}) : License? {
+        if let view = viewResolver.resolveView(Type<License>()) {
+            if let v = view as? License {
+                return v
+            }
+        }
+        return nil
+    }
+
+    /// View to expose a URL to this item on an external site.
+    /// This can be used by applications like .find and Blocto to direct users 
+    /// to the original link for an NFT.
+    ///
     pub struct ExternalURL {
         pub let url: String
 
@@ -317,9 +463,24 @@ pub contract MetadataViews {
         }
     }
 
-    // A view to expose the information needed store and retrieve an NFT
-    //
-    // This can be used by applications to setup a NFT collection with proper storage and public capabilities.
+    /// Helper to get ExternalURL in a typesafe way
+    ///
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return A optional ExternalURL struct
+    ///
+    pub fun getExternalURL(_ viewResolver: &{Resolver}) : ExternalURL? {
+        if let view = viewResolver.resolveView(Type<ExternalURL>()) {
+            if let v = view as? ExternalURL {
+                return v
+            }
+        }
+        return nil
+    }
+
+    /// View to expose the information needed store and retrieve an NFT.
+    /// This can be used by applications to setup a NFT collection with proper 
+    /// storage and public capabilities.
+    ///
     pub struct NFTCollectionData {
         /// Path in storage where this NFT is recommended to be stored.
         pub let storagePath: StoragePath
@@ -375,10 +536,24 @@ pub contract MetadataViews {
         }
     }
 
-    // A view to expose the information needed to showcase this NFT's collection
-    //
-    // This can be used by applications to give an overview and graphics of the NFT collection
-    // this NFT belongs to.
+    /// Helper to get NFTCollectionData in a way that will return an typed Optional
+    ///
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return A optional NFTCollectionData struct
+    ///
+    pub fun getNFTCollectionData(_ viewResolver: &{Resolver}) : NFTCollectionData? {
+        if let view = viewResolver.resolveView(Type<NFTCollectionData>()) {
+            if let v = view as? NFTCollectionData {
+                return v
+            }
+        }
+        return nil
+    }
+
+    /// View to expose the information needed to showcase this NFT's
+    /// collection. This can be used by applications to give an overview and 
+    /// graphics of the NFT collection this NFT belongs to.
+    ///
     pub struct NFTCollectionDisplay {
         // Name that should be used when displaying this NFT collection.
         pub let name: String
@@ -416,9 +591,66 @@ pub contract MetadataViews {
         }
     }
 
-    // A view to represent a single field of metadata on an NFT.
-    //
-    // This is used to get traits of individual key/value pairs along with some contextualized data about the trait
+    /// Helper to get NFTCollectionDisplay in a way that will return a typed 
+    /// Optional
+    ///
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return A optional NFTCollection struct
+    ///
+    pub fun getNFTCollectionDisplay(_ viewResolver: &{Resolver}) : NFTCollectionDisplay? {
+        if let view = viewResolver.resolveView(Type<NFTCollectionDisplay>()) {
+            if let v = view as? NFTCollectionDisplay {
+                return v
+            }
+        }
+        return nil
+    }
+
+    /// View to expose rarity information for a single rarity
+    /// Note that a rarity needs to have either score or description but it can 
+    /// have both
+    ///
+    pub struct Rarity {
+        /// The score of the rarity as a number
+        pub let score: UFix64?
+
+        /// The maximum value of score
+        pub let max: UFix64?
+
+        /// The description of the rarity as a string.
+        ///
+        /// This could be Legendary, Epic, Rare, Uncommon, Common or any other string value
+        pub let description: String?
+
+        init(score: UFix64?, max: UFix64?, description: String?) {
+            if score == nil && description == nil {
+                panic("A Rarity needs to set score, description or both")
+            }
+
+            self.score = score
+            self.max = max
+            self.description = description
+        }
+    }
+
+    /// Helper to get Rarity view in a typesafe way
+    ///
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return A optional Rarity struct
+    ///
+    pub fun getRarity(_ viewResolver: &{Resolver}) : Rarity? {
+        if let view = viewResolver.resolveView(Type<Rarity>()) {
+            if let v = view as? Rarity {
+                return v
+            }
+        }
+        return nil
+    }
+
+    /// View to represent a single field of metadata on an NFT.
+    /// This is used to get traits of individual key/value pairs along with some
+    /// contextualized data about the trait
+    ///
     pub struct Trait {
         // The name of the trait. Like Background, Eyes, Hair, etc.
         pub let name: String
@@ -444,23 +676,48 @@ pub contract MetadataViews {
         }
     }
 
-    // A view to return all the traits on an NFT.
-    //
-    // This is used to return traits as individual key/value pairs along with some contextualized data about each trait.
+    /// Wrapper view to return all the traits on an NFT.
+    /// This is used to return traits as individual key/value pairs along with
+    /// some contextualized data about each trait.
     pub struct Traits {
         pub let traits: [Trait]
 
         init(_ traits: [Trait]) {
             self.traits = traits
         }
-
+            
+        /// Adds a single Trait to the Traits view
+        /// 
+        /// @param Trait: The trait struct to be added
+        ///
         pub fun addTrait(_ t: Trait) {
             self.traits.append(t)
         }
     }
 
-    // A helper function to easily convert a dictionary to traits. For NFT collections that do not need either of the
-    // optional values of a Trait, this method should suffice to give them an array of valid traits.
+    /// Helper to get Traits view in a typesafe way
+    ///
+    /// @param viewResolver: A reference to the resolver resource
+    /// @return A optional Traits struct
+    ///
+    pub fun getTraits(_ viewResolver: &{Resolver}) : Traits? {
+        if let view = viewResolver.resolveView(Type<Traits>()) {
+            if let v = view as? Traits {
+                return v
+            }
+        }
+        return nil
+    }
+
+    /// Helper function to easily convert a dictionary to traits. For NFT 
+    /// collections that do not need either of the optional values of a Trait, 
+    /// this method should suffice to give them an array of valid traits.
+    ///
+    /// @param dict: The dictionary to be converted to Traits
+    /// @param excludedNames: An optional String array specifying the `dict`
+    ///         keys that are not wanted to become `Traits`
+    /// @return The generated Traits view
+    ///
     pub fun dictToTraits(dict: {String: AnyStruct}, excludedNames: [String]?): Traits {
         // Collection owners might not want all the fields in their metadata included.
         // They might want to handle some specially, or they might just not want them included at all.
@@ -479,31 +736,5 @@ pub contract MetadataViews {
         return Traits(traits)
     }
 
-    /// Rarity information for a single rarity
-    //
-    /// Note that a rarity needs to have either score or description but it can have both
-    pub struct Rarity {
-        /// The score of the rarity as a number
-        ///
-        pub let score: UFix64?
-
-        /// The maximum value of score
-        ///
-        pub let max: UFix64?
-
-        /// The description of the rarity as a string.
-        ///
-        /// This could be Legendary, Epic, Rare, Uncommon, Common or any other string value
-        pub let description: String?
-
-        init(score: UFix64?, max: UFix64?, description: String?) {
-            if score == nil && description == nil {
-                panic("A Rarity needs to set score, description or both")
-            }
-
-            self.score = score
-            self.max = max
-            self.description = description
-        }
-    }
 }
+ 

--- a/contracts/utility/NFTCatalog.cdc
+++ b/contracts/utility/NFTCatalog.cdc
@@ -1,0 +1,342 @@
+import MetadataViews from "./MetadataViews.cdc"
+
+// NFTCatalog
+//
+// A general purpose NFT registry for Flow NonFungibleTokens.
+//
+// Each catalog entry stores data about the NFT including
+// its collection identifier, nft type, storage and public paths, etc.
+//
+// To make an addition to the catalog you can propose an NFT and provide its metadata.
+// An Admin can approve a proposal which would add the NFT to the catalog
+pub contract NFTCatalog {
+    // EntryAdded
+    // An NFT collection has been added to the catalog
+    pub event EntryAdded(
+        collectionIdentifier : String,
+        contractName : String,
+        contractAddress : Address,
+        nftType : Type,
+        storagePath: StoragePath,
+        publicPath: PublicPath,
+        privatePath: PrivatePath,
+        publicLinkedType : Type,
+        privateLinkedType : Type,
+        displayName : String,
+        description: String,
+        externalURL : String
+    )
+
+    // EntryUpdated
+    // An NFT Collection has been updated in the catalog
+    pub event EntryUpdated(
+        collectionIdentifier : String,
+        contractName : String,
+        contractAddress : Address,
+        nftType : Type,
+        storagePath: StoragePath,
+        publicPath: PublicPath,
+        privatePath: PrivatePath,
+        publicLinkedType : Type,
+        privateLinkedType : Type,
+        displayName : String,
+        description: String,
+        externalURL : String
+    )
+
+    // EntryRemoved
+    // An NFT Collection has been removed from the catalog
+    pub event EntryRemoved(collectionIdentifier : String)
+
+    // ProposalEntryAdded
+    // A new proposal to make an addtion to the catalog has been made
+    pub event ProposalEntryAdded(proposalID : UInt64, collectionIdentifier : String, message: String, status: String, proposer : Address)
+
+    // ProposalEntryUpdated
+    // A proposal has been updated
+    pub event ProposalEntryUpdated(proposalID : UInt64, collectionIdentifier : String, message: String, status: String, proposer : Address)
+
+    // ProposalEntryRemoved
+    // A proposal has been removed from storage
+    pub event ProposalEntryRemoved(proposalID : UInt64)
+
+    pub let ProposalManagerStoragePath: StoragePath
+
+    pub let ProposalManagerPublicPath: PublicPath
+
+    access(self) let catalog: {String : NFTCatalog.NFTCatalogMetadata} // { collectionIdentifier -> Metadata }
+    access(self) let catalogTypeData: {String : {String : Bool}} // Additional view to go from { NFT Type Identifier -> {Collection Identifier : Bool } }
+    access(self) let catalogProposals : {UInt64 : NFTCatalogProposal} // { ProposalID : Metadata }
+    access(self) var totalProposals : UInt64
+
+    // NFTCatalogProposalManager
+    // Used to authenticate proposals made to the catalog
+    pub resource interface NFTCatalogProposalManagerPublic {
+        pub fun getCurrentProposalEntry(): String?
+    }
+    pub resource NFTCatalogProposalManager : NFTCatalogProposalManagerPublic {
+            access(self) var currentProposalEntry: String?
+
+            pub fun getCurrentProposalEntry(): String? {
+                return self.currentProposalEntry
+            }
+
+            pub fun setCurrentProposalEntry(identifier: String?) {
+                self.currentProposalEntry = identifier
+            }
+
+            init () {
+                self.currentProposalEntry = nil
+            }
+    }
+
+    // NFTCollectionData
+    // Represents information about an NFT collection resource
+    // Note: Not suing the struct from Metadata standard due to
+    // inability to store functions
+    pub struct NFTCollectionData {
+
+        pub let storagePath : StoragePath
+        pub let publicPath : PublicPath
+        pub let privatePath: PrivatePath
+        pub let publicLinkedType: Type
+        pub let privateLinkedType: Type
+
+        init(
+            storagePath : StoragePath,
+            publicPath : PublicPath,
+            privatePath : PrivatePath,
+            publicLinkedType : Type,
+            privateLinkedType : Type
+        ) {
+            self.storagePath = storagePath
+            self.publicPath = publicPath
+            self.privatePath = privatePath
+            self.publicLinkedType = publicLinkedType
+            self.privateLinkedType = privateLinkedType
+        }
+    }
+
+    // NFTCatalogMetadata
+    // Represents data about an NFT
+    pub struct NFTCatalogMetadata {
+        pub let contractName : String
+        pub let contractAddress : Address
+        pub let nftType: Type
+        pub let collectionData: NFTCollectionData
+        pub let collectionDisplay: MetadataViews.NFTCollectionDisplay
+
+        init (contractName : String, contractAddress : Address, nftType: Type, collectionData : NFTCollectionData, collectionDisplay : MetadataViews.NFTCollectionDisplay) {
+            self.contractName = contractName
+            self.contractAddress = contractAddress
+            self.nftType = nftType
+            self.collectionData = collectionData
+            self.collectionDisplay = collectionDisplay
+        }
+    }
+
+    // NFTCatalogProposal
+    // Represents a proposal to the catalog
+    // Includes data about an NFT
+    pub struct NFTCatalogProposal {
+        pub let collectionIdentifier : String
+        pub let metadata : NFTCatalogMetadata
+        pub let message : String
+        pub let status : String
+        pub let proposer : Address
+        pub let createdTime : UFix64
+
+        init(collectionIdentifier : String, metadata : NFTCatalogMetadata, message : String, status : String, proposer : Address) {
+            self.collectionIdentifier = collectionIdentifier
+            self.metadata = metadata
+            self.message = message
+            self.status = status
+            self.proposer = proposer
+            self.createdTime = getCurrentBlock().timestamp
+        }
+    }
+
+    pub fun getCatalog() : {String : NFTCatalogMetadata} {
+        return self.catalog
+    }
+
+    pub fun getCatalogEntry(collectionIdentifier : String) : NFTCatalogMetadata? {
+        return self.catalog[collectionIdentifier]
+    }
+
+    pub fun getCollectionsForType(nftTypeIdentifier: String) : {String : Bool}? {
+        return self.catalogTypeData[nftTypeIdentifier]
+    }
+
+    pub fun getCatalogTypeData() : {String : {String : Bool}} {
+        return self.catalogTypeData
+    }
+
+    // Propose an NFT collection to the catalog
+    // @param collectionIdentifier: The unique name assinged to this nft collection
+    // @param metadata: The Metadata for the NFT collection that will be stored in the catalog
+    // @param message: A message to the catalog owners
+    // @param proposer: Who is making the proposition(the address needs to be verified)
+    pub fun proposeNFTMetadata(collectionIdentifier : String, metadata : NFTCatalogMetadata, message : String, proposer : Address) : UInt64 {
+        let proposerManagerCap = getAccount(proposer).getCapability<&NFTCatalogProposalManager{NFTCatalog.NFTCatalogProposalManagerPublic}>(NFTCatalog.ProposalManagerPublicPath)
+
+        assert(proposerManagerCap.check(), message : "Proposer needs to set up a manager")
+
+        let proposerManagerRef = proposerManagerCap.borrow()!
+
+        assert(proposerManagerRef.getCurrentProposalEntry()! == collectionIdentifier, message: "Expected proposal entry does not match entry for the proposer")
+
+        let catalogProposal = NFTCatalogProposal(collectionIdentifier : collectionIdentifier, metadata : metadata, message : message, status: "IN_REVIEW", proposer: proposer)
+        self.totalProposals = self.totalProposals + 1
+        self.catalogProposals[self.totalProposals] = catalogProposal
+
+        emit ProposalEntryAdded(proposalID : self.totalProposals, collectionIdentifier : collectionIdentifier, message: catalogProposal.message, status: catalogProposal.status, proposer: catalogProposal.proposer)
+        return self.totalProposals
+    }
+
+    // Withdraw a proposal from the catalog
+    // @param proposalID: The ID of proposal you want to withdraw
+    pub fun withdrawNFTProposal(proposalID : UInt64) {
+        pre {
+            self.catalogProposals[proposalID] != nil : "Invalid Proposal ID"
+        }
+        let proposal = self.catalogProposals[proposalID]!
+        let proposer = proposal.proposer
+
+        let proposerManagerCap = getAccount(proposer).getCapability<&NFTCatalogProposalManager{NFTCatalog.NFTCatalogProposalManagerPublic}>(NFTCatalog.ProposalManagerPublicPath)
+
+        assert(proposerManagerCap.check(), message : "Proposer needs to set up a manager")
+
+        let proposerManagerRef = proposerManagerCap.borrow()!
+
+        assert(proposerManagerRef.getCurrentProposalEntry()! == proposal.collectionIdentifier, message: "Expected proposal entry does not match entry for the proposer")
+
+        self.removeCatalogProposal(proposalID : proposalID)
+    }
+
+    pub fun getCatalogProposals() : {UInt64 : NFTCatalogProposal} {
+        return self.catalogProposals
+    }
+
+    pub fun getCatalogProposalEntry(proposalID : UInt64) : NFTCatalogProposal? {
+        return self.catalogProposals[proposalID]
+    }
+
+    pub fun createNFTCatalogProposalManager(): @NFTCatalogProposalManager {
+        return <-create NFTCatalogProposalManager()
+    }
+
+    // NOTE: Made pub for testing.
+    pub fun addCatalogEntry(collectionIdentifier : String, metadata: NFTCatalogMetadata) {
+        pre {
+            self.catalog[collectionIdentifier] == nil : "The nft name has already been added to the catalog"
+        }
+
+        self.addCatalogTypeEntry(collectionIdentifier : collectionIdentifier , metadata: metadata)
+
+        self.catalog[collectionIdentifier] = metadata
+
+        emit EntryAdded(
+            collectionIdentifier : collectionIdentifier,
+            contractName : metadata.contractName,
+            contractAddress : metadata.contractAddress,
+            nftType: metadata.nftType,
+            storagePath: metadata.collectionData.storagePath,
+            publicPath: metadata.collectionData.publicPath,
+            privatePath: metadata.collectionData.privatePath,
+            publicLinkedType : metadata.collectionData.publicLinkedType,
+            privateLinkedType : metadata.collectionData.privateLinkedType,
+            displayName : metadata.collectionDisplay.name,
+            description: metadata.collectionDisplay.description,
+            externalURL : metadata.collectionDisplay.externalURL.url
+        )
+    }
+
+    access(account) fun updateCatalogEntry(collectionIdentifier : String , metadata: NFTCatalogMetadata) {
+        pre {
+            self.catalog[collectionIdentifier] != nil : "Invalid collection identifier"
+        }
+        // remove previous nft type entry
+        self.removeCatalogTypeEntry(collectionIdentifier : collectionIdentifier , metadata: metadata)
+        // add updated nft type entry
+        self.addCatalogTypeEntry(collectionIdentifier : collectionIdentifier , metadata: metadata)
+
+        self.catalog[collectionIdentifier] = metadata
+
+        let nftType = metadata.nftType
+
+        emit EntryUpdated(
+            collectionIdentifier : collectionIdentifier,
+            contractName : metadata.contractName,
+            contractAddress : metadata.contractAddress,
+            nftType: metadata.nftType,
+            storagePath: metadata.collectionData.storagePath,
+            publicPath: metadata.collectionData.publicPath,
+            privatePath: metadata.collectionData.privatePath,
+            publicLinkedType : metadata.collectionData.publicLinkedType,
+            privateLinkedType : metadata.collectionData.privateLinkedType,
+            displayName : metadata.collectionDisplay.name,
+            description: metadata.collectionDisplay.description,
+            externalURL : metadata.collectionDisplay.externalURL.url
+        )
+    }
+
+    access(account) fun removeCatalogEntry(collectionIdentifier : String) {
+        pre {
+            self.catalog[collectionIdentifier] != nil : "Invalid collection identifier"
+        }
+
+        self.removeCatalogTypeEntry(collectionIdentifier : collectionIdentifier , metadata: self.catalog[collectionIdentifier]!)
+        self.catalog.remove(key: collectionIdentifier)
+
+        emit EntryRemoved(collectionIdentifier : collectionIdentifier)
+    }
+
+    access(account) fun updateCatalogProposal(proposalID: UInt64, proposalMetadata : NFTCatalogProposal) {
+        self.catalogProposals[proposalID] = proposalMetadata
+
+        emit ProposalEntryUpdated(proposalID : proposalID, collectionIdentifier : proposalMetadata.collectionIdentifier, message: proposalMetadata.message, status: proposalMetadata.status, proposer: proposalMetadata.proposer)
+    }
+
+    access(account) fun removeCatalogProposal(proposalID : UInt64) {
+        self.catalogProposals.remove(key : proposalID)
+
+        emit ProposalEntryRemoved(proposalID : proposalID)
+    }
+
+    access(contract) fun addCatalogTypeEntry(collectionIdentifier : String , metadata: NFTCatalogMetadata) {
+        if self.catalogTypeData[metadata.nftType.identifier] != nil {
+            let typeData : {String : Bool} = self.catalogTypeData[metadata.nftType.identifier]!
+            assert(self.catalogTypeData[metadata.nftType.identifier]![collectionIdentifier] == nil, message : "The nft name has already been added to the catalog")
+            typeData[collectionIdentifier] = true
+            self.catalogTypeData[metadata.nftType.identifier] = typeData
+        } else {
+            let typeData : {String : Bool} = {}
+            typeData[collectionIdentifier] = true
+            self.catalogTypeData[metadata.nftType.identifier] = typeData
+        }
+    }
+
+    access(contract) fun removeCatalogTypeEntry(collectionIdentifier : String , metadata: NFTCatalogMetadata) {
+        let prevMetadata = self.catalog[collectionIdentifier]!
+        let prevCollectionsForType = self.catalogTypeData[prevMetadata.nftType.identifier]!
+        prevCollectionsForType.remove(key : collectionIdentifier)
+        if prevCollectionsForType.length == 0 {
+            self.catalogTypeData.remove(key: prevMetadata.nftType.identifier)
+        } else {
+            self.catalogTypeData[prevMetadata.nftType.identifier] = prevCollectionsForType
+        }
+    }
+
+    init() {
+        self.ProposalManagerStoragePath = /storage/nftCatalogProposalManager
+        self.ProposalManagerPublicPath = /public/nftCatalogProposalManager
+
+        self.totalProposals = 0
+        self.catalog = {}
+        self.catalogTypeData = {}
+
+        self.catalogProposals = {}
+    }
+
+}

--- a/flow.json
+++ b/flow.json
@@ -1,45 +1,50 @@
 {
-  "emulators": {
-    "default": {
-      "port": 3569,
-      "serviceAccount": "emulator-account"
-    }
-  },
-  "contracts": {
-    "NFTStorefront": "./contracts/NFTStorefront.cdc",
-    "NFTStorefrontV2": "./contracts/NFTStorefrontV2.cdc",
-    "FungibleToken": {
-      "source": "./contracts/utility/FungibleToken.cdc",
-      "aliases": {
-        "emulator": "0xee82856bf20e2aa6",
-        "testnet": "0x9a0766d93b6608b7"
-      }
+    "emulators": {
+        "default": {
+            "port": 3569,
+            "serviceAccount": "emulator-account"
+        }
     },
-    "NonFungibleToken": {
-      "source": "./contracts/utility/NonFungibleToken.cdc",
-      "aliases": {
-        "emulator": "0xf8d6e0586b0a20c7",
-        "testnet": "0x631e88ae7f1d7c20"
-      }
+    "contracts": {
+        "NFTStorefront": "./contracts/NFTStorefront.cdc",
+        "NFTStorefrontV2": "./contracts/NFTStorefrontV2.cdc",
+        "FungibleToken": {
+            "source": "./contracts/utility/FungibleToken.cdc",
+            "aliases": {
+                "emulator": "0xee82856bf20e2aa6",
+                "testnet": "0x9a0766d93b6608b7"
+            }
+        },
+        "NonFungibleToken": {
+            "source": "./contracts/utility/NonFungibleToken.cdc",
+            "aliases": {
+                "emulator": "0xf8d6e0586b0a20c7",
+                "testnet": "0x631e88ae7f1d7c20"
+            }
+        },
+        "NFTCatalog": {
+            "source": "./contracts/utility/NFTCatalog.cdc",
+            "aliases": {
+                "emulator": "0xf8d6e0586b0a20c7",
+                "testnet": "0x324c34e1c517e4db",
+                "mainnet": "0x49a7cda3a1eecc29"
+            }
+        }
+    },
+    "networks": {
+        "emulator": "127.0.0.1:3569",
+        "mainnet": "access.mainnet.nodes.onflow.org:9000",
+        "testnet": "access.devnet.nodes.onflow.org:9000"
+    },
+    "accounts": {
+        "emulator-account": {
+            "address": "0xf8d6e0586b0a20c7",
+            "key": "$FLOW_EMULATOR_PRIVATE_KEY"
+        }
+    },
+    "deployments": {
+        "emulator": {
+            "emulator-account": ["NFTStorefrontV2"]
+        }
     }
-  },
-  "networks": {
-    "emulator": "127.0.0.1:3569",
-    "mainnet": "access.mainnet.nodes.onflow.org:9000",
-    "testnet": "access.devnet.nodes.onflow.org:9000"
-  },
-  "accounts": {
-    "emulator-account": {
-      "address": "0xf8d6e0586b0a20c7",
-      "key": ""
-    }
-  },
-  "deployments": {
-    "emulator": {
-      "emulator-account": [
-        "NFTStorefrontV2"
-      ]
-    }
-  }
 }
- 

--- a/lib/js/mocks/transactions/setup_nft_account.cdc
+++ b/lib/js/mocks/transactions/setup_nft_account.cdc
@@ -1,4 +1,5 @@
 import NonFungibleToken from "../../../../contracts/utility/NonFungibleToken.cdc"
+import MetadataViews from "../../../../contracts/utility/MetadataViews.cdc"
 import ExampleNFT from "../../../../contracts/utility/ExampleNFT.cdc"
 
 // This transaction is what an account would run
@@ -19,7 +20,7 @@ transaction {
         signer.save(<-collection, to: ExampleNFT.CollectionStoragePath)
 
         // create a public capability for the collection
-        signer.link<&{NonFungibleToken.CollectionPublic, ExampleNFT.ExampleNFTCollectionPublic}>(
+        signer.link<&{NonFungibleToken.CollectionPublic, ExampleNFT.ExampleNFTCollectionPublic, MetadataViews.ResolverCollection}>(
             ExampleNFT.CollectionPublicPath,
             target: ExampleNFT.CollectionStoragePath
         )

--- a/lib/js/mocks/transactions/setup_nft_catalog.cdc
+++ b/lib/js/mocks/transactions/setup_nft_catalog.cdc
@@ -1,0 +1,42 @@
+import NonFungibleToken from "../../../../contracts/utility/NonFungibleToken.cdc"
+import MetadataViews from "../../../../contracts/utility/MetadataViews.cdc"
+import NFTCatalog from "../../../../contracts/utility/NFTCatalog.cdc"
+import ExampleNFT from "../../../../contracts/utility/ExampleNFT.cdc"
+
+// This transaction sets up a fake NFT catalog for testing.
+
+transaction {
+    prepare(signer: AuthAccount) {
+        NFTCatalog.addCatalogEntry(
+            collectionIdentifier: "ExampleNFT", 
+            metadata: NFTCatalog.NFTCatalogMetadata(
+                contractName: "ExampleNFT", 
+                contractAddress: 0xf8d6e0586b0a20c7, 
+                nftType: Type<@ExampleNFT.NFT>(), 
+                collectionData: NFTCatalog.NFTCollectionData(
+                    storagePath: /storage/exampleNFTCollection, 
+                    publicPath: /public/exampleNFTCollection, 
+                    privatePath: /private/exampleNFTCollection,
+                    publicLinkedType: Type<&ExampleNFT.Collection{ExampleNFT.ExampleNFTCollectionPublic,NonFungibleToken.CollectionPublic,NonFungibleToken.Receiver,MetadataViews.ResolverCollection}>(),
+                    privateLinkedType: Type<&ExampleNFT.Collection{ExampleNFT.ExampleNFTCollectionPublic,NonFungibleToken.CollectionPublic,NonFungibleToken.Provider,MetadataViews.ResolverCollection}>()),
+                collectionDisplay: MetadataViews.NFTCollectionDisplay(
+                    name: "ExampleNFT", 
+                    description: "ExampleNFT", 
+                    externalURL: MetadataViews.ExternalURL("https://example.com/image.png"),
+                    squareImage: MetadataViews.Media(
+                        file: MetadataViews.HTTPFile(
+                            url: "https://assets.website-files.com/5f6294c0c7a8cdd643b1c820/5f6294c0c7a8cda55cb1c936_Flow_Wordmark.svg"
+                        ),
+                        mediaType: "image/svg+xml"
+                    ),
+                    bannerImage: MetadataViews.Media(
+                        file: MetadataViews.HTTPFile(
+                            url: "https://assets.website-files.com/5f6294c0c7a8cdd643b1c820/5f6294c0c7a8cda55cb1c936_Flow_Wordmark.svg"
+                        ),
+                        mediaType: "image/svg+xml"
+                    ),
+                    socials: {})
+            )
+        )
+    }
+}

--- a/lib/js/test/package-lock.json
+++ b/lib/js/test/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "test",
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
@@ -4406,7 +4407,6 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {
@@ -6070,7 +6070,6 @@
         "@jest/types": "^24.9.0",
         "anymatch": "^2.0.0",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^1.2.7",
         "graceful-fs": "^4.1.15",
         "invariant": "^2.2.4",
         "jest-serializer": "^24.9.0",
@@ -6325,7 +6324,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.9",
         "jest-regex-util": "^28.0.2",
         "jest-util": "^28.0.2",

--- a/lib/js/test/tests/nft-storefront-v2-via-catalog.test.js
+++ b/lib/js/test/tests/nft-storefront-v2-via-catalog.test.js
@@ -1,0 +1,1117 @@
+import path from "path";
+import {
+    emulator,
+    init,
+    getAccountAddress,
+    deployContractByName,
+    sendTransaction,
+    shallPass,
+    executeScript,
+    shallRevert,
+    getFlowBalance,
+    mintFlow,
+} from "flow-js-testing";
+import fs from "fs";
+
+const setup_nft_catalog_tx = fs.readFileSync(
+    path.resolve(__dirname, "../../mocks/transactions/setup_nft_catalog.cdc"),
+    { encoding: "utf8", flag: "r" }
+);
+const setup_nft_account_tx = fs.readFileSync(
+    path.resolve(__dirname, "../../mocks/transactions/setup_nft_account.cdc"),
+    { encoding: "utf8", flag: "r" }
+);
+const mint_nft_tx = fs.readFileSync(
+    path.resolve(__dirname, "../../mocks/transactions/mint_nft.cdc"),
+    { encoding: "utf8", flag: "r" }
+);
+const get_owned_nft_ids_script = fs.readFileSync(
+    path.resolve(__dirname, "../../mocks/scripts/get_owned_nft_ids.cdc"),
+    { encoding: "utf8", flag: "r" }
+);
+const setup_account_to_receive_royalty_tx = fs.readFileSync(
+    path.resolve(
+        __dirname,
+        "../../mocks/transactions/setup_account_to_receive_royalty.cdc"
+    ),
+    { encoding: "utf8", flag: "r" }
+);
+
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function deployContract(param) {
+    const [result, error] = await deployContractByName(param);
+    if (error != null) {
+        console.log(`Error in deployment - ${error}`);
+        emulator.stop();
+        process.exit(1);
+    }
+}
+
+async function getCurrentTimestamp() {
+    const code = `
+    pub fun main(): UInt64 {
+      return UInt64(getCurrentBlock().timestamp)
+    }
+  `;
+    return await executeScript({ code });
+}
+
+async function getListingKeys(account) {
+    const read_storefront_ids_script = fs.readFileSync(
+        path.resolve(__dirname, "../../../../scripts/read_storefront_ids.cdc"),
+        { encoding: "utf8", flag: "r" }
+    );
+    const [scriptResult, sError] = await executeScript({
+        code: read_storefront_ids_script,
+        args: [account],
+    });
+    return scriptResult;
+}
+
+async function getDuplicateListingIDs(account, nftId, listingId) {
+    const read_duplicate_listing_ids_script = fs.readFileSync(
+        path.resolve(
+            __dirname,
+            "../../../../scripts/read_duplicate_listing_ids.cdc"
+        ),
+        { encoding: "utf8", flag: "r" }
+    );
+    const [scriptResult, sError] = await executeScript({
+        code: read_duplicate_listing_ids_script,
+        args: [account, nftId, listingId],
+    });
+    return scriptResult;
+}
+
+async function getListingDetails(account, resourceId) {
+    const read_listing_details_script = fs.readFileSync(
+        path.resolve(__dirname, "../../../../scripts/read_listing_details.cdc"),
+        { encoding: "utf8", flag: "r" }
+    );
+    const [scriptResult, sError] = await executeScript({
+        code: read_listing_details_script,
+        args: [account, resourceId],
+    });
+    return scriptResult;
+}
+
+async function getAllowedCommissionReceivers(account, resourceId) {
+    const read_allowed_commission_receivers = fs.readFileSync(
+        path.resolve(
+            __dirname,
+            "../../../../scripts/read_allowed_commission_receivers.cdc"
+        ),
+        { encoding: "utf8", flag: "r" }
+    );
+    const [scriptResult, sError] = await executeScript({
+        code: read_allowed_commission_receivers,
+        args: [account, resourceId],
+    });
+    return scriptResult;
+}
+
+async function getRoyaltyBalance(account) {
+    const code = `import FlowToken from 0x0ae53cb6e3f42a79
+  import MetadataViews from "../../../../contracts/utility/MetadataViews.cdc"
+  import FungibleToken from "../../../../contracts/utility/FungibleToken.cdc"
+
+  pub fun main(target: Address): UFix64 {
+    let cap = getAccount(target).getCapability<&{FungibleToken.Balance}>(MetadataViews.getRoyaltyReceiverPublicPath())
+    let vaultRef = cap.borrow() ?? panic("Could not borrow Balance reference to the Vault")
+    return vaultRef.balance
+  }
+  `;
+    const [balance, sError] = await executeScript({
+        code: code,
+        args: [account],
+    });
+    return balance;
+}
+
+async function doesFlowTokenReceiverCapabilityExists(account) {
+    const check_capability_script = `import FlowToken from 0x0ae53cb6e3f42a79
+    import FungibleToken from "../../../../contracts/utility/FungibleToken.cdc"
+
+    pub fun main(target: Address): Bool {
+      let cap = getAccount(target).getCapability<&FlowToken.Vault{FungibleToken.Receiver}>(/public/flowTokenReceiver)
+      return cap.check()
+    }
+    `;
+    const [isCapabilityExists, sError] = await executeScript({
+        code: check_capability_script,
+        args: [account],
+    });
+    return isCapabilityExists;
+}
+
+describe("NFTStorefrontV2", () => {
+    let exampleNFTContractAddress;
+    let nftStorefrontContractAddress;
+    let fungibleTokenContractAddress;
+    let metadataViewsContractAddress;
+    let catalogContractAddress;
+    let nonFungibleTokenContractAddress;
+    let seller_1;
+    let seller_2;
+    let buyer_1;
+    let buyer_2;
+    let artist_1;
+    let artist_2;
+    let marketplace_1;
+    let marketplace_2;
+
+    beforeEach(async () => {
+        const basePath = path.resolve(__dirname, "../../../../");
+        // You can specify different port to parallelize execution of describe blocks
+        const port = 8080;
+        // Setting logging flag to true will pipe emulator output to console
+        const logging = false;
+
+        await init(basePath, { port });
+        await emulator.start(port, { logging });
+
+        // Deployed at address which has the alias - nftStoreFrontV2
+        nftStorefrontContractAddress = await getAccountAddress(
+            "nftStoreFrontV2"
+        );
+        // Deployed at address which has the alias - fungibleToken
+        fungibleTokenContractAddress = await getAccountAddress("fungibleToken");
+        // Deployed at address which has the alias - metadataViews
+        metadataViewsContractAddress = await getAccountAddress("metadataViews");
+        // Deployed at address which has the alias - nftCatalog
+        catalogContractAddress = await getAccountAddress("nftCatalog");
+        // Deployed at address which has the alias - nonFungibleToken
+        nonFungibleTokenContractAddress = await getAccountAddress(
+            "nonFungibleToken"
+        );
+        // Deployed at address which has the alias - exampleNFT
+        exampleNFTContractAddress = await getAccountAddress("exampleNFT");
+
+        await deployContract({
+            to: fungibleTokenContractAddress,
+            name: "utility/FungibleToken",
+        });
+        await deployContract({
+            to: nonFungibleTokenContractAddress,
+            name: "utility/NonFungibleToken",
+        });
+        await deployContract({
+            to: metadataViewsContractAddress,
+            name: "utility/MetadataViews",
+        });
+        await deployContract({
+            to: catalogContractAddress,
+            name: "utility/NFTCatalog",
+        });
+        await deployContract({
+            to: nftStorefrontContractAddress,
+            name: "NFTStorefrontV2",
+        });
+        await deployContract({
+            to: exampleNFTContractAddress,
+            name: "utility/ExampleNFT",
+        });
+
+        seller_1 = await getAccountAddress("seller_1");
+        seller_2 = await getAccountAddress("seller_2");
+        buyer_1 = await getAccountAddress("buyer_1");
+        buyer_2 = await getAccountAddress("buyer_2");
+        artist_1 = await getAccountAddress("artist_1");
+        artist_2 = await getAccountAddress("artist_2");
+        marketplace_1 = await getAccountAddress("marketplace_1");
+        marketplace_2 = await getAccountAddress("marketplace_2");
+
+        await shallPass(
+            sendTransaction({
+                code: setup_nft_catalog_tx,
+                args: [],
+                signers: [catalogContractAddress],
+            })
+        );
+    });
+
+    // Stop emulator, so it could be restarted
+    afterEach(async () => {
+        return emulator.stop();
+    });
+
+    test("should able to install the storefront manager in the account", async () => {
+        await shallPass(
+            sendTransaction({
+                name: "setup_account",
+                args: [],
+                signers: [seller_1],
+            })
+        );
+    });
+
+    test("should successfully list the sale item", async () => {
+        // step 1 : Setup a collection for seller_1
+        await shallPass(
+            sendTransaction({
+                code: setup_nft_account_tx,
+                args: [],
+                signers: [seller_1],
+            })
+        );
+
+        // step 2: Mint NFT for seller_1 with no royalties
+        await shallPass(
+            sendTransaction({
+                code: mint_nft_tx,
+                args: [
+                    seller_1,
+                    "NFT1",
+                    "This is to sell",
+                    "abc.jpeg",
+                    [],
+                    [],
+                    [],
+                ],
+                signers: [exampleNFTContractAddress],
+            })
+        );
+
+        // Verify the Id of the NFT that get minted
+        const [result, e] = await executeScript({
+            code: get_owned_nft_ids_script,
+            args: [seller_1],
+        });
+        expect(result.length).toBe(1);
+        expect(result[0]).toEqual(0);
+
+        // Check the capability for the flow token
+        expect(
+            await doesFlowTokenReceiverCapabilityExists(seller_1)
+        ).toBeTruthy();
+
+        // Step 3: List NFT to sell, It would list the nft for the sale with commission can be grab by anyone.
+
+        // Step 3.a: Below transaction would fail because seller_1 doesn't have the storefront manager install in the account.
+        const currentTimestamp = parseInt(await getCurrentTimestamp());
+        const [txResult, error] = await shallRevert(
+            sendTransaction({
+                name: "sell_item_via_catalog",
+                args: [
+                    "ExampleNFT",
+                    0,
+                    "50.50",
+                    "TopShot Platform",
+                    "10.50",
+                    currentTimestamp + 500,
+                    [],
+                ],
+                signers: [seller_1],
+            })
+        );
+
+        // Make sure transaction did not go through.
+        expect(txResult).toEqual(null);
+
+        // TODO: Create some utility that would allow to match the error string with the thrown error.
+        console.log(
+            `Error for the transaction that need to reverted - ${error}`
+        );
+
+        // Step 3.b: Install the storefront manager in the seller_1 account.
+        await shallPass(
+            sendTransaction({
+                name: "setup_account",
+                args: [],
+                signers: [seller_1],
+            })
+        );
+
+        // Step 3.c: Should success as seller_1 has the storefront manager resource
+        const [txResult_2, error_2] = await shallPass(
+            sendTransaction({
+                name: "sell_item_via_catalog",
+                // Use 0 for the commission amount to make sure it supports the creation of the sale at 0 commission.
+                args: [
+                    "ExampleNFT",
+                    0,
+                    "50.50",
+                    "TopShot Platform",
+                    "0",
+                    currentTimestamp + 500,
+                    [],
+                ],
+                signers: [seller_1],
+            })
+        );
+
+        // Make sure transaction did go through.
+        expect(error_2).toEqual(null);
+
+        // Validate the details
+        let listingKeys = await getListingKeys(seller_1);
+        expect(listingKeys.length).toEqual(1);
+
+        let listingDetails = await getListingDetails(seller_1, listingKeys[0]);
+        expect(listingDetails.purchased).toBeFalsy();
+        expect(parseInt(listingDetails.expiry)).toEqual(currentTimestamp + 500);
+        expect(listingDetails.customID).toEqual("TopShot Platform");
+        expect(listingDetails.salePrice).toEqual("50.50000000");
+    });
+
+    test("should successfully list the sale item with royalty and marketplace address", async () => {
+        // step 1 : Setup a collection for seller_1
+        await shallPass(
+            sendTransaction({
+                code: setup_nft_account_tx,
+                args: [],
+                signers: [seller_1],
+            })
+        );
+
+        // step 2: Mint NFT for seller_1 with royalties fail because the artists don't have the receiver capability.
+        const [txResult_nft_mint, error_nft_mint] = await shallRevert(
+            sendTransaction({
+                code: mint_nft_tx,
+                args: [
+                    seller_1,
+                    "NFT1",
+                    "This is to sell",
+                    "abc.jpeg",
+                    ["0.1", "0.25"],
+                    ["Artist_1", "Artist_2"],
+                    [artist_1, artist_2],
+                ],
+                signers: [exampleNFTContractAddress],
+            })
+        );
+
+        // Make sure transaction did not go through.
+        expect(txResult_nft_mint).toEqual(null);
+
+        // step 3: Mint NFT for seller_1 with royalties
+        // step 3.a: Provide the receiver capability.
+
+        // For artist_1
+        await shallPass(
+            sendTransaction({
+                code: setup_account_to_receive_royalty_tx,
+                args: [],
+                signers: [artist_1],
+            })
+        );
+
+        // For artist_2
+        await shallPass(
+            sendTransaction({
+                code: setup_account_to_receive_royalty_tx,
+                args: [],
+                signers: [artist_2],
+            })
+        );
+
+        await shallPass(
+            sendTransaction({
+                code: mint_nft_tx,
+                args: [
+                    seller_1,
+                    "NFT1",
+                    "This is to sell",
+                    "abc.jpeg",
+                    ["0.1", "0.25"],
+                    ["Artist_1", "Artist_2"],
+                    [artist_1, artist_2],
+                ],
+                signers: [exampleNFTContractAddress],
+            })
+        );
+
+        // Verify the Id of the NFT that get minted
+        const [result, e] = await executeScript({
+            code: get_owned_nft_ids_script,
+            args: [seller_1],
+        });
+        expect(result.length).toBe(1);
+        expect(result[0]).toEqual(0);
+
+        // Check the capability for the flow token
+        expect(
+            await doesFlowTokenReceiverCapabilityExists(seller_1)
+        ).toBeTruthy();
+
+        // Step 4: List NFT to sell, It would list the nft for the sale with commission can be grab by anyone.
+        const currentTimestamp = parseInt(await getCurrentTimestamp());
+
+        // Step 4.a: Install the storefront manager in the seller_1 account.
+        await shallPass(
+            sendTransaction({
+                name: "setup_account",
+                args: [],
+                signers: [seller_1],
+            })
+        );
+
+        // Step 4.b: Should success as seller_1 has the storefront manager resource with marketplace address
+        const [txResult_2, error_2] = await shallPass(
+            sendTransaction({
+                name: "sell_item_via_catalog",
+                args: [
+                    "ExampleNFT",
+                    0,
+                    "50.50",
+                    "TopShot Platform",
+                    "10.50",
+                    currentTimestamp + 500,
+                    [marketplace_1, marketplace_2],
+                ],
+                signers: [seller_1],
+            })
+        );
+
+        // Make sure transaction did go through.
+        expect(error_2).toEqual(null);
+
+        // Validate the details
+        let listingKeys = await getListingKeys(seller_1);
+        expect(listingKeys.length).toEqual(1);
+
+        let listingDetails = await getListingDetails(seller_1, listingKeys[0]);
+        expect(listingDetails.purchased).toBeFalsy();
+        expect(parseInt(listingDetails.expiry)).toEqual(currentTimestamp + 500);
+        expect(listingDetails.customID).toEqual("TopShot Platform");
+        expect(listingDetails.salePrice).toEqual("50.50000000");
+        // Make sure that anybody can retrieve the list of the marketplaces capability supported by the listing.
+        const allowedCommissionRecv = await getAllowedCommissionReceivers(
+            seller_1,
+            listingKeys[0]
+        );
+        console.log(allowedCommissionRecv);
+        expect(allowedCommissionRecv[0].address).toEqual(marketplace_1);
+        expect(allowedCommissionRecv[1].address).toEqual(marketplace_2);
+    });
+
+    test("should successfully list the same item multiple times and then purchase one of the listing that removes other duplicates programmatically", async () => {
+        // step 1 : Setup a collection for seller_1
+        await shallPass(
+            sendTransaction({
+                code: setup_nft_account_tx,
+                args: [],
+                signers: [seller_1],
+            })
+        );
+
+        // step 2: Mint NFT for seller_1 with royalties
+        // step 2.a: Provide the receiver capability.
+
+        // For artist_1
+        await shallPass(
+            sendTransaction({
+                code: setup_account_to_receive_royalty_tx,
+                args: [],
+                signers: [artist_1],
+            })
+        );
+
+        // For artist_2
+        await shallPass(
+            sendTransaction({
+                code: setup_account_to_receive_royalty_tx,
+                args: [],
+                signers: [artist_2],
+            })
+        );
+
+        // Mint the NFT
+        await shallPass(
+            sendTransaction({
+                code: mint_nft_tx,
+                args: [
+                    seller_1,
+                    "NFT1",
+                    "This is to sell",
+                    "abc.jpeg",
+                    ["0.1", "0.25"],
+                    ["Artist_1", "Artist_2"],
+                    [artist_1, artist_2],
+                ],
+                signers: [exampleNFTContractAddress],
+            })
+        );
+
+        // Verify the Id of the NFT that get minted
+        const [result, e] = await executeScript({
+            code: get_owned_nft_ids_script,
+            args: [seller_1],
+        });
+        expect(result.length).toBe(1);
+        expect(result[0]).toEqual(0);
+
+        // Check the capability for the flow token
+        expect(
+            await doesFlowTokenReceiverCapabilityExists(seller_1)
+        ).toBeTruthy();
+
+        // Step 4: List NFT to sell, It would list the nft for the sale with commission can be grab by anyone.
+        const currentTimestamp = parseInt(await getCurrentTimestamp());
+
+        // Step 4.a: Install the storefront manager in the seller_1 account.
+        await shallPass(
+            sendTransaction({
+                name: "setup_account",
+                args: [],
+                signers: [seller_1],
+            })
+        );
+
+        // Step 4.b: Should success as seller_1 has the storefront manager resource with marketplace address
+        let [txResult_2, error_2] = await shallPass(
+            sendTransaction({
+                name: "sell_item_via_catalog",
+                args: [
+                    "ExampleNFT",
+                    0,
+                    "50.50",
+                    "TopShot Platform",
+                    "10.50",
+                    currentTimestamp + 500,
+                    [marketplace_1, marketplace_2],
+                ],
+                signers: [seller_1],
+            })
+        );
+
+        // Make sure transaction did go through.
+        expect(error_2).toEqual(null);
+
+        // Validate the details
+        let listingKeys = await getListingKeys(seller_1);
+        expect(listingKeys.length).toEqual(1);
+
+        let listingDetails = await getListingDetails(seller_1, listingKeys[0]);
+        expect(listingDetails.purchased).toBeFalsy();
+        expect(parseInt(listingDetails.expiry)).toEqual(currentTimestamp + 500);
+        expect(listingDetails.customID).toEqual("TopShot Platform");
+        expect(listingDetails.salePrice).toEqual("50.50000000");
+
+        const artist_1_flow_balance_before = await getRoyaltyBalance(artist_1);
+        const artist_2_flow_balance_before = await getRoyaltyBalance(artist_2);
+        const [marketplace_1_flow_balance_before] = await getFlowBalance(
+            marketplace_1
+        );
+        const [marketplace_2_flow_balance_before] = await getFlowBalance(
+            marketplace_2
+        );
+
+        // Again list the same NFT
+        // Step 5: Should success as seller_1 has the storefront manager resource with marketplace address
+        [txResult_2, error_2] = await shallPass(
+            sendTransaction({
+                name: "sell_item_via_catalog",
+                args: [
+                    "ExampleNFT",
+                    0,
+                    "50.50",
+                    "TopShot Platform Duplicate List",
+                    "12.50",
+                    currentTimestamp + 800,
+                    [
+                        await getAccountAddress("marketplace_3"),
+                        await getAccountAddress("marketplace_4"),
+                    ],
+                ],
+                signers: [seller_1],
+            })
+        );
+
+        const listingKeys_2 = await getListingKeys(seller_1);
+        expect(listingKeys_2.length).toEqual(2);
+
+        let duplicateListing = await getDuplicateListingIDs(
+            seller_1,
+            listingDetails.nftID,
+            listingKeys[0]
+        );
+        expect(duplicateListing.length).toEqual(1);
+
+        //////////////
+        // Purchase///
+        //////////////
+
+        // Mint effective salePrice amount to buyer_1
+        await mintFlow(buyer_1, "1000.0");
+        const [flowBalance] = await getFlowBalance(buyer_1);
+        console.log(`Flow balance for buyer 1 - ${flowBalance}`);
+
+        // Should fail as buyer don't have the NFT collection receiver.
+        const [txResult_purchase, error_purchase] = await shallRevert(
+            sendTransaction({
+                name: "buy_item_via_catalog",
+                args: ["ExampleNFT", listingKeys[0], seller_1, seller_2],
+                signers: [buyer_1],
+            })
+        );
+
+        // Make sure the transaction fails
+        expect(txResult_purchase).toEqual(null);
+
+        console.log(
+            `Error during first attempt of purchase - ${error_purchase}`
+        );
+
+        // Install NFT receiver in the buyer account
+        await shallPass(
+            sendTransaction({
+                code: setup_nft_account_tx,
+                args: [],
+                signers: [buyer_1],
+            })
+        );
+
+        // Should fail as commission can only be send to marketplaces.
+        const [txResult_purchase_2, error_purchase_2] = await shallRevert(
+            sendTransaction({
+                name: "buy_item_via_catalog",
+                args: ["ExampleNFT", listingKeys[0], seller_1, seller_2],
+                signers: [buyer_1],
+            })
+        );
+
+        // Make sure the transaction fails
+        expect(txResult_purchase_2).toEqual(null);
+
+        console.log(
+            `Error during Second attempt of purchase - ${error_purchase_2}`
+        );
+
+        const [seller_1_balance_before] = await getFlowBalance(seller_1);
+        // Should successfully purchase the nft
+        const [txResult_purchase_3, error_purchase_3] = await shallPass(
+            sendTransaction({
+                name: "buy_item_via_catalog",
+                args: ["ExampleNFT", listingKeys[0], seller_1, marketplace_1],
+                signers: [buyer_1],
+            })
+        );
+
+        // Make sure the transaction fails
+        expect(error_purchase_3).toEqual(null);
+
+        // Verify the royalty and commission received by the entitled capabilities.
+        const artist_1_flow_balance_after = await getRoyaltyBalance(artist_1);
+        const artist_2_flow_balance_after = await getRoyaltyBalance(artist_2);
+        const [marketplace_1_flow_balance_after] = await getFlowBalance(
+            marketplace_1
+        );
+        const [marketplace_2_flow_balance_after] = await getFlowBalance(
+            marketplace_2
+        );
+        const [seller_1_balance_after] = await getFlowBalance(seller_1);
+
+        expect(
+            parseFloat(marketplace_1_flow_balance_after) -
+                parseFloat(marketplace_1_flow_balance_before)
+        ).toEqual(parseFloat("10.50"));
+        expect(
+            parseFloat(marketplace_2_flow_balance_after) -
+                parseFloat(marketplace_2_flow_balance_before)
+        ).toEqual(parseFloat("0.0"));
+        expect(
+            parseFloat(artist_1_flow_balance_after) -
+                parseFloat(artist_1_flow_balance_before)
+        ).toEqual(parseFloat("4.0"));
+        expect(
+            parseFloat(artist_2_flow_balance_after) -
+                parseFloat(artist_2_flow_balance_before)
+        ).toEqual(parseFloat("10.0"));
+        expect(
+            parseFloat(seller_1_balance_after) -
+                parseFloat(seller_1_balance_before)
+        ).toEqual(parseFloat("26.0"));
+
+        // Verify the buyer got the NFT.
+        const [nft_ids] = await executeScript({
+            code: get_owned_nft_ids_script,
+            args: [buyer_1],
+        });
+        expect(nft_ids.length).toBe(1);
+        expect(result[0]).toEqual(0);
+
+        // Duplicate listing get deleted.
+        const listingKeys_3 = await getListingKeys(seller_1);
+        expect(listingKeys_3.length).toEqual(1);
+    });
+
+    test("should successfully list the item with the zero commission receipt and buy with it", async () => {
+        // step 1 : Setup a collection for seller_1
+        await shallPass(
+            sendTransaction({
+                code: setup_nft_account_tx,
+                args: [],
+                signers: [seller_1],
+            })
+        );
+
+        // step 2: Mint NFT for seller_1 with royalties
+        // step 2.a: Provide the receiver capability.
+
+        // For artist_1
+        await shallPass(
+            sendTransaction({
+                code: setup_account_to_receive_royalty_tx,
+                args: [],
+                signers: [artist_1],
+            })
+        );
+
+        // For artist_2
+        await shallPass(
+            sendTransaction({
+                code: setup_account_to_receive_royalty_tx,
+                args: [],
+                signers: [artist_2],
+            })
+        );
+
+        // Mint the NFT
+        await shallPass(
+            sendTransaction({
+                code: mint_nft_tx,
+                args: [
+                    seller_1,
+                    "NFT1",
+                    "This is to sell",
+                    "abc.jpeg",
+                    ["0.1", "0.25"],
+                    ["Artist_1", "Artist_2"],
+                    [artist_1, artist_2],
+                ],
+                signers: [exampleNFTContractAddress],
+            })
+        );
+
+        // Verify the Id of the NFT that get minted
+        const [result, e] = await executeScript({
+            code: get_owned_nft_ids_script,
+            args: [seller_1],
+        });
+        expect(result.length).toBe(1);
+        expect(result[0]).toEqual(0);
+
+        // Check the capability for the flow token
+        expect(
+            await doesFlowTokenReceiverCapabilityExists(seller_1)
+        ).toBeTruthy();
+
+        // Step 4: List NFT to sell, It would list the nft for the sale with commission can be grab by anyone.
+        const currentTimestamp = parseInt(await getCurrentTimestamp());
+
+        // Step 4.a: Install the storefront manager in the seller_1 account.
+        await shallPass(
+            sendTransaction({
+                name: "setup_account",
+                args: [],
+                signers: [seller_1],
+            })
+        );
+
+        // Step 4.b: Should success as seller_1 has the storefront manager resource with marketplace address
+        let [txResult_2, error_2] = await shallPass(
+            sendTransaction({
+                name: "sell_item_via_catalog",
+                args: [
+                    "ExampleNFT",
+                    0,
+                    "50.50",
+                    "TopShot Platform",
+                    "0.0",
+                    currentTimestamp + 500,
+                    [marketplace_1, marketplace_2],
+                ],
+                signers: [seller_1],
+            })
+        );
+
+        // Make sure transaction did go through.
+        expect(error_2).toEqual(null);
+
+        // Validate the details
+        let listingKeys = await getListingKeys(seller_1);
+        expect(listingKeys.length).toEqual(1);
+
+        let listingDetails = await getListingDetails(seller_1, listingKeys[0]);
+        expect(listingDetails.purchased).toBeFalsy();
+        expect(parseInt(listingDetails.expiry)).toEqual(currentTimestamp + 500);
+        expect(listingDetails.customID).toEqual("TopShot Platform");
+        expect(listingDetails.salePrice).toEqual("50.50000000");
+
+        //////////////
+        // Purchase///
+        //////////////
+
+        // Mint effective salePrice amount to buyer_1
+        await mintFlow(buyer_1, "1000.0");
+        const [flowBalance] = await getFlowBalance(buyer_1);
+        console.log(`Flow balance for buyer 1 - ${flowBalance}`);
+
+        // Install NFT receiver in the buyer account
+        await shallPass(
+            sendTransaction({
+                code: setup_nft_account_tx,
+                args: [],
+                signers: [buyer_1],
+            })
+        );
+
+        // Should fail as commission can only be send to marketplaces.
+        const [txResult_purchase, error_purchase] = await shallPass(
+            sendTransaction({
+                name: "buy_item_via_catalog",
+                args: ["ExampleNFT", listingKeys[0], seller_1, null],
+                signers: [buyer_1],
+            })
+        );
+
+        // Make sure the transaction fails
+        expect(error_purchase).toEqual(null);
+
+        // Verify the buyer got the NFT.
+        const [nft_ids] = await executeScript({
+            code: get_owned_nft_ids_script,
+            args: [buyer_1],
+        });
+        expect(nft_ids.length).toBe(1);
+        expect(result[0]).toEqual(0);
+    });
+
+    test("Cleanup expired listings", async () => {
+        // step 1 : Setup a collection for seller_1
+        await shallPass(
+            sendTransaction({
+                code: setup_nft_account_tx,
+                args: [],
+                signers: [seller_1],
+            })
+        );
+
+        // step 2: Mint NFT for seller_1 with no royalties
+        await shallPass(
+            sendTransaction({
+                code: mint_nft_tx,
+                args: [
+                    seller_1,
+                    "NFT1",
+                    "This is to sell",
+                    "abc.jpeg",
+                    [],
+                    [],
+                    [],
+                ],
+                signers: [exampleNFTContractAddress],
+            })
+        );
+
+        // step 2: Mint NFT for seller_1 with no royalties
+        await shallPass(
+            sendTransaction({
+                code: mint_nft_tx,
+                args: [
+                    seller_1,
+                    "NFT2",
+                    "This is to sell as well",
+                    "xyz.jpeg",
+                    [],
+                    [],
+                    [],
+                ],
+                signers: [exampleNFTContractAddress],
+            })
+        );
+
+        // step 2: Mint NFT for seller_1 with no royalties
+        await shallPass(
+            sendTransaction({
+                code: mint_nft_tx,
+                args: [
+                    seller_1,
+                    "NFT3",
+                    "This is to sell as well",
+                    "ama.jpeg",
+                    [],
+                    [],
+                    [],
+                ],
+                signers: [exampleNFTContractAddress],
+            })
+        );
+
+        // Step 3: Install the storefront manager in the seller_1 account.
+        await shallPass(
+            sendTransaction({
+                name: "setup_account",
+                args: [],
+                signers: [seller_1],
+            })
+        );
+
+        const currentTimestamp = parseInt(await getCurrentTimestamp());
+
+        // Step 3.c: Should successfully create the multiple listings
+        await shallPass(
+            sendTransaction({
+                name: "sell_item_via_catalog",
+                args: [
+                    "ExampleNFT",
+                    0,
+                    "50.50",
+                    "TopShot Platform 1",
+                    "10.50",
+                    currentTimestamp + 2,
+                    [],
+                ],
+                signers: [seller_1],
+            })
+        );
+
+        let listingKeysT = await getListingKeys(seller_1);
+        console.log(JSON.stringify(listingKeysT));
+
+        await shallPass(
+            sendTransaction({
+                name: "sell_item_via_catalog",
+                args: [
+                    "ExampleNFT",
+                    1,
+                    "50.50",
+                    "TopShot Platform 2",
+                    "10.50",
+                    currentTimestamp + 3,
+                    [],
+                ],
+                signers: [seller_1],
+            })
+        );
+
+        listingKeysT = await getListingKeys(seller_1);
+        console.log(JSON.stringify(listingKeysT));
+
+        await shallPass(
+            sendTransaction({
+                name: "sell_item_via_catalog",
+                args: [
+                    "ExampleNFT",
+                    2,
+                    "50.50",
+                    "TopShot Platform 3",
+                    "10.50",
+                    currentTimestamp + 4,
+                    [],
+                ],
+                signers: [seller_1],
+            })
+        );
+
+        listingKeysT = await getListingKeys(seller_1);
+        console.log(JSON.stringify(listingKeysT));
+
+        await shallPass(
+            sendTransaction({
+                name: "sell_item_via_catalog",
+                args: [
+                    "ExampleNFT",
+                    2,
+                    "50.50",
+                    "TopShot Platform 4",
+                    "10.50",
+                    currentTimestamp + 15,
+                    [],
+                ],
+                signers: [seller_1],
+            })
+        );
+
+        listingKeysT = await getListingKeys(seller_1);
+        console.log(JSON.stringify(listingKeysT));
+
+        console.log(`Timestamp before the time jump - ${currentTimestamp}`);
+
+        // For waiting
+        await sleep(16000);
+
+        ////////////////////
+        /////// Purchase //
+        ///////////////////
+
+        // Mint effective salePrice amount to buyer_1
+        await mintFlow(buyer_1, "1000.0");
+
+        // Install NFT receiver in the buyer account
+        await shallPass(
+            sendTransaction({
+                code: setup_nft_account_tx,
+                args: [],
+                signers: [buyer_1],
+            })
+        );
+
+        // Validate the details
+        let listingKeys = await getListingKeys(seller_1);
+        expect(listingKeys.length).toEqual(4);
+        console.log(JSON.stringify(listingKeys));
+
+        console.log(
+            `Timestamp after the time jump - ${parseInt(
+                await getCurrentTimestamp()
+            )}`
+        );
+
+        // Should fail because listing is expired.
+        const [txResult_purchase, error_purchase] = await shallRevert(
+            sendTransaction({
+                name: "buy_item_via_catalog",
+                args: ["ExampleNFT", listingKeys[0], seller_1, seller_2],
+                signers: [buyer_1],
+            })
+        );
+
+        // Make sure the transaction fails
+        expect(txResult_purchase).toEqual(null);
+
+        console.log(
+            `Error during first attempt of purchase - ${error_purchase}`
+        );
+
+        // Fail to cleanup the listing as provided range is out of bound
+        let [txResult_cleanup, error_cleanup] = await shallRevert(
+            sendTransaction({
+                name: "cleanup_expired_listings",
+                args: [0, 6, seller_1],
+                signers: [buyer_1],
+            })
+        );
+
+        // Make sure the transaction succeed
+        expect(txResult_cleanup).toEqual(null);
+
+        // Fail to cleanup the listing because of incorrect start index
+        [txResult_cleanup, error_cleanup] = await shallRevert(
+            sendTransaction({
+                name: "cleanup_expired_listings",
+                args: [5, 3, seller_1],
+                signers: [buyer_1],
+            })
+        );
+
+        // Make sure the transaction succeed
+        expect(txResult_cleanup).toEqual(null);
+
+        // Cleanup the listings
+        [txResult_cleanup, error_cleanup] = await shallPass(
+            sendTransaction({
+                name: "cleanup_expired_listings",
+                args: [0, 3, seller_1],
+                signers: [buyer_1],
+            })
+        );
+
+        // Make sure the transaction succeed
+        expect(error_cleanup).toEqual(null);
+    });
+});

--- a/transactions/buy_item_via_catalog.cdc
+++ b/transactions/buy_item_via_catalog.cdc
@@ -1,0 +1,74 @@
+import FlowToken from 0x0ae53cb6e3f42a79
+import FungibleToken from "../contracts/utility/FungibleToken.cdc"
+import NonFungibleToken from "../contracts/utility/NonFungibleToken.cdc"
+import NFTCatalog from "../contracts/utility/NFTCatalog.cdc"
+import NFTStorefrontV2 from "../contracts/NFTStorefrontV2.cdc"
+
+/// Transaction facilitates the purcahse of listed NFT.
+/// It takes the storefront address, listing resource that need
+/// to be purchased & a address that will takeaway the commission.
+///
+/// Buyer of the listing (,i.e. underling NFT) would authorize and sign the
+/// transaction and if purchase happens then transacted NFT would store in
+/// buyer's collection.
+
+transaction(collectionIdentifier: String, listingResourceID: UInt64, storefrontAddress: Address, commissionRecipient: Address?) {
+    let paymentVault: @FungibleToken.Vault
+    let catalog: {String : NFTCatalog.NFTCatalogMetadata}
+    let collection: &AnyResource{NonFungibleToken.CollectionPublic}
+    let storefront: &NFTStorefrontV2.Storefront{NFTStorefrontV2.StorefrontPublic}
+    let listing: &NFTStorefrontV2.Listing{NFTStorefrontV2.ListingPublic}
+    var commissionRecipientCap: Capability<&{FungibleToken.Receiver}>?
+
+    prepare(acct: AuthAccount) {
+        self.catalog = NFTCatalog.getCatalog()
+        assert(self.catalog.containsKey(collectionIdentifier), message: "Provided collection is not in the NFT Catalog.")
+        let value = self.catalog[collectionIdentifier]!
+        let collectionCap = acct.getCapability<&AnyResource{NonFungibleToken.CollectionPublic}>(value.collectionData.publicPath)
+        // Access the buyer's NFT collection to store the purchased NFT.
+        self.collection = collectionCap.borrow() ?? panic("Cannot borrow NFT collection receiver from account")
+
+        self.commissionRecipientCap = nil
+        // Access the storefront public resource of the seller to purchase the listing.
+        self.storefront = getAccount(storefrontAddress)
+            .getCapability<&NFTStorefrontV2.Storefront{NFTStorefrontV2.StorefrontPublic}>(
+                NFTStorefrontV2.StorefrontPublicPath
+            )!
+            .borrow()
+            ?? panic("Could not borrow Storefront from provided address")
+
+        // Borrow the listing
+        self.listing = self.storefront.borrowListing(listingResourceID: listingResourceID)
+                    ?? panic("No Offer with that ID in Storefront")
+        let price = self.listing.getDetails().salePrice
+
+        // Access the vault of the buyer to pay the sale price of the listing.
+        let mainFlowVault = acct.borrow<&FlowToken.Vault>(from: /storage/flowTokenVault)
+            ?? panic("Cannot borrow FlowToken vault from acct storage")
+        self.paymentVault <- mainFlowVault.withdraw(amount: price)
+
+        // Fetch the commission amt.
+        let commissionAmount = self.listing.getDetails().commissionAmount
+
+        if commissionRecipient != nil && commissionAmount != 0.0 {
+            // Access the capability to receive the commission.
+            let _commissionRecipientCap = getAccount(commissionRecipient!).getCapability<&{FungibleToken.Receiver}>(/public/flowTokenReceiver)
+            assert(_commissionRecipientCap.check(), message: "Commission Recipient doesn't have flowtoken receiving capability")
+            self.commissionRecipientCap = _commissionRecipientCap
+        } else if commissionAmount == 0.0 {
+            self.commissionRecipientCap = nil
+        } else {
+            panic("Commission recipient can not be empty when commission amount is non zero")
+        }
+    }
+
+    execute {
+        // Purchase the NFT
+        let item <- self.listing.purchase(
+            payment: <-self.paymentVault,
+            commissionRecipient: self.commissionRecipientCap
+        )
+        // Deposit the NFT in the buyer's collection.
+        self.collection.deposit(token: <-item)
+    }
+}

--- a/transactions/sell_item_via_catalog.cdc
+++ b/transactions/sell_item_via_catalog.cdc
@@ -36,7 +36,7 @@ transaction(collectionIdentifier: String, saleItemID: UInt64, saleItemPrice: UFi
         self.marketplacesCapability = []
 
         // We need a provider capability, but one is not provided by default so we create one if needed.
-        let exampleNFTCollectionProviderPrivatePath = /private/exampleNFTCollectionProviderForNFTStorefront
+        let nftCollectionProviderPrivatePath = /private/nftCollectionProviderForNFTStorefront
 
         // Receiver for the sale cut.
         self.flowReceiver = acct.getCapability<&{FungibleToken.Receiver}>(/public/flowTokenReceiver)
@@ -44,14 +44,14 @@ transaction(collectionIdentifier: String, saleItemID: UInt64, saleItemPrice: UFi
 
         // Check if the Provider capability exists or not if `no` then create a new link for the same.
         // TODO: When MetadataViews default implementation is available, use the following lines.
-        // if !acct.getCapability<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(exampleNFTCollectionProviderPrivatePath).check() {
-        //     acct.link<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(exampleNFTCollectionProviderPrivatePath, target: value.collectionData.storagePath)
+        // if !acct.getCapability<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(nftCollectionProviderPrivatePath).check() {
+        //     acct.link<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(nftCollectionProviderPrivatePath, target: value.collectionData.storagePath)
         // }
-        if !acct.getCapability<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic, MetadataViews.ResolverCollection}>(exampleNFTCollectionProviderPrivatePath).check() {
-            acct.link<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic, MetadataViews.ResolverCollection}>(exampleNFTCollectionProviderPrivatePath, target: value.collectionData.storagePath)
+        if !acct.getCapability<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic, MetadataViews.ResolverCollection}>(nftCollectionProviderPrivatePath).check() {
+            acct.link<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic, MetadataViews.ResolverCollection}>(nftCollectionProviderPrivatePath, target: value.collectionData.storagePath)
         }
 
-        self.collectionCap = acct.getCapability<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic, MetadataViews.ResolverCollection}>(exampleNFTCollectionProviderPrivatePath)
+        self.collectionCap = acct.getCapability<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic, MetadataViews.ResolverCollection}>(nftCollectionProviderPrivatePath)
         let collection = self.collectionCap.borrow<>()
             ?? panic("Could not borrow a reference to the collection")
         var totalRoyaltyCut = 0.0

--- a/transactions/sell_item_via_catalog.cdc
+++ b/transactions/sell_item_via_catalog.cdc
@@ -1,0 +1,101 @@
+import FlowToken from 0x0ae53cb6e3f42a79
+import FungibleToken from "../contracts/utility/FungibleToken.cdc"
+import NonFungibleToken from "../contracts/utility/NonFungibleToken.cdc"
+import MetadataViews from "../contracts/utility/MetadataViews.cdc"
+import NFTCatalog from "../contracts/utility/NFTCatalog.cdc"
+import NFTStorefrontV2 from "../contracts/NFTStorefrontV2.cdc"
+
+/// Transaction used to facilitate the creation of the listing under the signer's owned storefront resource.
+/// It accepts the certain details from the signer,i.e. - 
+///
+/// `saleItemID` - ID of the NFT that is put on sale by the seller.
+/// `saleItemPrice` - Amount of tokens (FT) buyer needs to pay for the purchase of listed NFT.
+/// `customID` - Optional string to represent identifier of the dapp.
+/// `commissionAmount` - Commission amount that will be taken away by the purchase facilitator.
+/// `expiry` - Unix timestamp at which created listing become expired.
+/// `marketplacesAddress` - List of addresses that are allowed to get the commission.
+
+/// If the given nft has a support of the RoyaltyView then royalties will added as the sale cut.
+
+transaction(collectionIdentifier: String, saleItemID: UInt64, saleItemPrice: UFix64, customID: String?, commissionAmount: UFix64, expiry: UInt64, marketplacesAddress: [Address]) {
+    let flowReceiver: Capability<&AnyResource{FungibleToken.Receiver}>
+    let catalog: {String : NFTCatalog.NFTCatalogMetadata}
+    // TODO: When MetadataViews default implementation is available, use the following line.
+    // let collectionCap: Capability<&AnyResource{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>
+    let collectionCap: Capability<&AnyResource{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic, MetadataViews.ResolverCollection}>
+    let storefront: &NFTStorefrontV2.Storefront
+    var saleCuts: [NFTStorefrontV2.SaleCut]
+    var marketplacesCapability: [Capability<&AnyResource{FungibleToken.Receiver}>]
+
+    prepare(acct: AuthAccount) {
+        self.catalog = NFTCatalog.getCatalog()
+        assert(self.catalog.containsKey(collectionIdentifier), message: "Provided collection is not in the NFT Catalog.")
+        let value = self.catalog[collectionIdentifier]!
+
+        self.saleCuts = []
+        self.marketplacesCapability = []
+
+        // We need a provider capability, but one is not provided by default so we create one if needed.
+        let exampleNFTCollectionProviderPrivatePath = /private/exampleNFTCollectionProviderForNFTStorefront
+
+        // Receiver for the sale cut.
+        self.flowReceiver = acct.getCapability<&{FungibleToken.Receiver}>(/public/flowTokenReceiver)
+        assert(self.flowReceiver.borrow() != nil, message: "Missing or mis-typed FlowToken receiver")
+
+        // Check if the Provider capability exists or not if `no` then create a new link for the same.
+        // TODO: When MetadataViews default implementation is available, use the following lines.
+        // if !acct.getCapability<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(exampleNFTCollectionProviderPrivatePath).check() {
+        //     acct.link<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic}>(exampleNFTCollectionProviderPrivatePath, target: value.collectionData.storagePath)
+        // }
+        if !acct.getCapability<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic, MetadataViews.ResolverCollection}>(exampleNFTCollectionProviderPrivatePath).check() {
+            acct.link<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic, MetadataViews.ResolverCollection}>(exampleNFTCollectionProviderPrivatePath, target: value.collectionData.storagePath)
+        }
+
+        self.collectionCap = acct.getCapability<&{NonFungibleToken.Provider, NonFungibleToken.CollectionPublic, MetadataViews.ResolverCollection}>(exampleNFTCollectionProviderPrivatePath)
+        let collection = self.collectionCap.borrow<>()
+            ?? panic("Could not borrow a reference to the collection")
+        var totalRoyaltyCut = 0.0
+        let effectiveSaleItemPrice = saleItemPrice - commissionAmount
+        let views = collection.borrowViewResolver(id: saleItemID)
+        // Check whether the NFT implements the MetadataResolver or not.
+        if views.getViews().contains(Type<MetadataViews.Royalties>()) {
+            let royaltiesRef = views.resolveView(Type<MetadataViews.Royalties>())?? panic("Unable to retrieve the royalties")
+            let royalties = (royaltiesRef as! MetadataViews.Royalties).getRoyalties()
+            for royalty in royalties {
+                // TODO - Verify the type of the vault and it should exists
+                self.saleCuts.append(NFTStorefrontV2.SaleCut(receiver: royalty.receiver, amount: royalty.cut * effectiveSaleItemPrice))
+                totalRoyaltyCut = totalRoyaltyCut + royalty.cut * effectiveSaleItemPrice
+            }
+        }
+        // Append the cut for the seller.
+        self.saleCuts.append(NFTStorefrontV2.SaleCut(
+            receiver: self.flowReceiver,
+            amount: effectiveSaleItemPrice - totalRoyaltyCut
+        ))
+        assert(self.collectionCap.borrow() != nil, message: "Missing or mis-typed NonFungibleToken.Provider, NonFungibleToken.CollectionPublic provider")
+
+        self.storefront = acct.borrow<&NFTStorefrontV2.Storefront>(from: NFTStorefrontV2.StorefrontStoragePath)
+            ?? panic("Missing or mis-typed NFTStorefront Storefront")
+
+        for marketplace in marketplacesAddress {
+            // Here we are making a fair assumption that all given addresses would have
+            // the capability to receive the `FlowToken`
+            self.marketplacesCapability.append(getAccount(marketplace).getCapability<&{FungibleToken.Receiver}>(/public/flowTokenReceiver))
+        }
+    }
+
+    execute {
+        // Create listing
+        self.storefront.createListing(
+            nftProviderCapability: self.collectionCap,
+            nftType: self.catalog[collectionIdentifier]!.nftType,
+            nftID: saleItemID,
+            salePaymentVaultType: Type<@FlowToken.Vault>(),
+            saleCuts: self.saleCuts,
+            marketplacesCapability: self.marketplacesCapability.length == 0 ? nil : self.marketplacesCapability,
+            customID: customID,
+            commissionAmount: commissionAmount,
+            expiry: expiry
+        )
+    }
+}


### PR DESCRIPTION
This PR integrates with the NFT Catalog to simplify the buy/sell transactions (remove the need for importing the specific NFT contracts).

NOTE: For the `sell_item_via_catalog`, we currently link in the `MetadataViews.ResolverCollection`, once the https://github.com/onflow/cadence/pull/1076 change is out, we can uncomment the lines I have in the transaction to further simplify the code.

## Testing
```
make && npm test
```