### PR TITLE
Add cleanup purchased listing function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,11 @@ test:
 .PHONY: ci
 ci:
 	$(MAKE) ci -C lib/go
+
+.PHONY: update-mainnet
+update-mainnet:
+	$(MAKE) flow accounts update-contract NFTStorefrontV2 ./contracts/NFTStorefrontV2.cdc --signer mainnet-account --network mainnet -f ./flow.mainnet.json
+
+.PHONY: update-testnet
+update-testnet:
+	$(MAKE) flow accounts update-contract NFTStorefrontV2 ./contracts/NFTStorefrontV2.cdc --signer testnet-account --network testnet -f ./flow.testnet.json

--- a/contracts/NFTStorefrontV2.cdc
+++ b/contracts/NFTStorefrontV2.cdc
@@ -628,7 +628,7 @@ pub contract NFTStorefrontV2 {
         
         /// removeListing
         /// Remove a Listing that has not yet been purchased from the collection and destroy it.
-        /// It is only be executed by the StorefrontManager resource owner.
+        /// It can only be executed by the StorefrontManager resource owner.
         ///
         pub fun removeListing(listingResourceID: UInt64) {
             let listing <- self.listings.remove(key: listingResourceID)

--- a/contracts/NFTStorefrontV2.cdc
+++ b/contracts/NFTStorefrontV2.cdc
@@ -511,6 +511,8 @@ pub contract NFTStorefrontV2 {
         pub fun borrowListing(listingResourceID: UInt64): &Listing{ListingPublic}?
         pub fun cleanupExpiredListings(fromIndex: UInt64, toIndex: UInt64)
         access(contract) fun cleanup(listingResourceID: UInt64)
+        pub fun getExistingListingIDs(nftType: Type, nftID: UInt64): [UInt64]
+        pub fun cleanupPurchasedListings(listingResourceID: UInt64)
    }
 
     /// Storefront
@@ -626,6 +628,7 @@ pub contract NFTStorefrontV2 {
         
         /// removeListing
         /// Remove a Listing that has not yet been purchased from the collection and destroy it.
+        /// It is only be executed by the StorefrontManager resource owner.
         ///
         pub fun removeListing(listingResourceID: UInt64) {
             let listing <- self.listings.remove(key: listingResourceID)
@@ -652,6 +655,21 @@ pub contract NFTStorefrontV2 {
             }
             var listingIDs = self.listedNFTs[nftType.identifier]![nftID]!
             return listingIDs
+        }
+
+        /// cleanupPurchasedListings
+        /// Allows anyone to remove already purchased listings.
+        ///
+        pub fun cleanupPurchasedListings(listingResourceID: UInt64) {
+            pre {
+                self.listings[listingResourceID] != nil: "could not find listing with given id"
+                self.borrowListing(listingResourceID: listingResourceID)!.getDetails().purchased == true: "listing not purchased yet"
+            }
+            let listing <- self.listings.remove(key: listingResourceID)!
+            let listingDetails = listing.getDetails()
+            self.removeDuplicateListing(nftIdentifier: listingDetails.nftType.identifier, nftID: listingDetails.nftID, listingResourceID: listingResourceID)
+
+            destroy listing
         }
 
         /// getDuplicateListingIDs

--- a/flow.mainnet.json
+++ b/flow.mainnet.json
@@ -1,0 +1,33 @@
+{
+    "contracts": {
+      "NFTStorefrontV2": "./contracts/NFTStorefrontV2.cdc",
+      "FungibleToken": {
+        "source": "./contracts/utility/FungibleToken.cdc",
+        "aliases": {
+          "mainnet": "0xf233dcee88fe0abe"
+        }
+      },
+      "NonFungibleToken": {
+        "source": "./contracts/utility/NonFungibleToken.cdc",
+        "aliases": {
+          "mainnet": "0x1d7e57aa55817448"
+        }
+      }
+    },
+    "networks": {
+      "mainnet": "access.mainnet.nodes.onflow.org:9000"
+    },
+    "accounts": {
+      "mainnet-account": {
+        "address": "0x4eb8a10cb9f87357",
+        "key": "$MAINNET_KEY"
+      }
+    },
+    "deployments": {
+      "mainnet": {
+        "mainnet-account": [
+          "NFTStorefrontV2"
+        ]
+      }
+    }
+  }

--- a/flow.testnet.json
+++ b/flow.testnet.json
@@ -1,19 +1,31 @@
 {
-  "accounts": {
-    "nft-storefront-v2-testnet": {
-      "address": "0x2d55b98eb200daef",
-      "key": "${PRIVATE_KEY}"
+  "contracts": {
+    "NFTStorefrontV2": "./contracts/NFTStorefrontV2.cdc",
+    "FungibleToken": {
+      "source": "./contracts/utility/FungibleToken.cdc",
+      "aliases": {
+        "testnet": "0x9a0766d93b6608b7"
+      }
+    },
+    "NonFungibleToken": {
+      "source": "./contracts/utility/NonFungibleToken.cdc",
+      "aliases": {
+        "testnet": "0x631e88ae7f1d7c20"
+      }
     }
   },
-  "contracts": {
-      "NFTStorefrontV2": "./contracts/NFTStorefrontV2.cdc"
-  },
   "networks": {
-      "testnet": "access.devnet.nodes.onflow.org:9000"
+    "testnet": "access.devnet.nodes.onflow.org:9000"
+  },
+  "accounts": {
+    "testnet-account": {
+      "address": "0x2d55b98eb200daef",
+      "key": "$TESTNET_KEY"
+    }
   },
   "deployments": {
     "testnet": {
-      "nft-storefront-v2-testnet": [
+      "testnet-account": [
         "NFTStorefrontV2"
       ]
     }

--- a/lib/js/test/tests/nft-storefront-v2.test.js
+++ b/lib/js/test/tests/nft-storefront-v2.test.js
@@ -653,6 +653,22 @@ describe("NFTStorefrontV2", ()=> {
     // Duplicate listing get deleted.
     const listingKeys_3 = await getListingKeys(seller_1);
     expect(listingKeys_3.length).toEqual(1);
+
+    // Remove the purchase listing
+    const [txResult_cleanup, error_cleanup] = await shallPass( 
+      sendTransaction({
+        name: "cleanup_purchased_listings",
+        args: [seller_1, listingKeys[0]],
+        signers: [buyer_1]
+      })
+    );
+
+    expect(txResult_cleanup.statusCode).toEqual(0);
+    expect(error_cleanup).toEqual(null);
+
+    // Make sure no key is left
+    const _listingKeys = await getListingKeys(seller_1);
+    expect(_listingKeys.length).toEqual(0);
   });
 
 

--- a/transactions/cleanup_purchased_listings.cdc
+++ b/transactions/cleanup_purchased_listings.cdc
@@ -1,0 +1,24 @@
+import NFTStorefrontV2 from "../contracts/NFTStorefrontV2.cdc"
+
+/// Transaction to facilitate the cleanup of the purchased listings of a given
+/// storefront resource account holder.
+///
+/// It can be sign/authorize by anyone.
+
+transaction(storefrontAddress: Address, listingResourceID: UInt64) {
+    let storefront: &NFTStorefrontV2.Storefront{NFTStorefrontV2.StorefrontPublic}
+
+    prepare(acct: AuthAccount) {
+        self.storefront = getAccount(storefrontAddress)
+            .getCapability<&NFTStorefrontV2.Storefront{NFTStorefrontV2.StorefrontPublic}>(
+                NFTStorefrontV2.StorefrontPublicPath
+            )!
+            .borrow()
+            ?? panic("Could not borrow Storefront from provided address")
+    }
+
+    execute {
+        // Be kind and recycle
+        self.storefront.cleanupPurchasedListings(listingResourceID: listingResourceID)
+    }
+}


### PR DESCRIPTION
This PR adds two functions to the StorefrontPublic resource interface.

- getExistingListingIDs - Returns an array of listing IDs of the given `nftType` and `nftID`.
- cleanupPurchasedListings - Allows anyone to remove already purchased listings.