### PR TITLE
Add paragraph to README about 0.42 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # NFT Storefront Contract Standard
 
+The version of the contracts in the `main` branch is the
+Cadence 1.0 version of the contracts and is not the same
+as the ones that are currently deployed to testnet and mainnet.
+See the `cadence-0.42` branch for the currently deployed versions.
+
 The NFT Storefront contract standard is a cornerstone of the Open Marketplace ecosystem on Flow. An open market ecosystem promotes the 
 free flow of NFT listings across the network, emitted as events and consumed by other marketplaces (or any other consumer). Marketplaces may filter 
 listings consumed based on commission rates they may receive. Listings may be created with variable commission, royalties or other fractional revenue, paying to multiple accounts. NFT listings are not NFTs, they are Resources which can be transacted with using the `purchase` [function](https://github.com/onflow/nft-storefront/blob/jp-update-structure/contracts/NFTStorefrontV2.cdc#L300) to obtain the token indicated by the listing. 


### PR DESCRIPTION
Adds a paragraph to the README mentioning the branch that has the 0.42 version of NFTStorefront contracts