### PR TITLE
fix borrowNFT method

### DIFF
--- a/contracts/NFTStorefrontV2.cdc
+++ b/contracts/NFTStorefrontV2.cdc
@@ -299,10 +299,12 @@ access(all) contract NFTStorefrontV2 {
         /// it will return nil.
         ///
         access(all) fun borrowNFT(): &{NonFungibleToken.NFT}? {
-            let ref = self.nftProviderCapability.borrow()!.borrowNFT(self.details.nftID)
-            if ref.isInstance(self.details.nftType) && ref?.id == self.details.nftID {
-                return ref as &{NonFungibleToken.NFT}?  
-            } 
+            if let ref = self.nftProviderCapability.borrow()!.borrowNFT(self.details.nftID) {
+                if ref.isInstance(self.details.nftType) && ref.id == self.details.nftID {
+                    return ref
+                }
+            }
+
             return nil
         }
 


### PR DESCRIPTION
The current definition of `borrowNFT` in the NFTStorefrontV2 definition does not work. This is because `ref` is of type `@{NonFungibleToken.NFT}?` not `@{NonFungibleToken.NFT}`. Because of this, `borrowNFT` currently always returns nil