### PR TITLE
Add Burner address replacement for Go package

### DIFF
--- a/lib/go/contracts/contracts.go
+++ b/lib/go/contracts/contracts.go
@@ -15,6 +15,8 @@ var (
 	fungibleTokenImport         = "FungibleToken from "
 	placeholderNonFungibleToken = regexp.MustCompile(`"NonFungibleToken"`)
 	nftImport                   = "NonFungibleToken from "
+	placeholderBurner           = regexp.MustCompile(`"Burner"`)
+	burnerImport                = "Burner from "
 )
 
 const (
@@ -22,11 +24,12 @@ const (
 )
 
 // NFTStorefrontV2 returns the NFTStorefrontV2 contract.
-func NFTStorefrontV2(ftAddr, nftAddr string) []byte {
+func NFTStorefrontV2(ftAddr, nftAddr, burnerAddr string) []byte {
 	code := assets.MustAssetString(filenameNFTStorefrontV2)
 
 	code = placeholderFungibleToken.ReplaceAllString(code, fungibleTokenImport+"0x"+ftAddr)
 	code = placeholderNonFungibleToken.ReplaceAllString(code, nftImport+"0x"+nftAddr)
+	code = placeholderBurner.ReplaceAllString(code, burnerImport+"0x"+burnerAddr)
 
 	return []byte(code)
 }

--- a/lib/go/contracts/contracts_test.go
+++ b/lib/go/contracts/contracts_test.go
@@ -11,6 +11,6 @@ import (
 const addrA = "0A"
 
 func TestNFTStorefrontV2Contract(t *testing.T) {
-	contract := contracts.NFTStorefrontV2(addrA, addrA)
+	contract := contracts.NFTStorefrontV2(addrA, addrA, addrA)
 	assert.NotNil(t, contract)
 }


### PR DESCRIPTION
## Summary

- Adds `Burner` contract address placeholder replacement in `NFTStorefrontV2` Go helper
- Updates `NFTStorefrontV2()` signature to accept a `burnerAddr` parameter
- Updates the corresponding test to pass the new argument

## Test plan

- [x] `go test ./...` in `lib/go/contracts`